### PR TITLE
Add initial xcodebuild.vim implementation

### DIFF
--- a/bin/find_scheme.sh
+++ b/bin/find_scheme.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 
-xcodebuild -list -project $@ \
+xcodebuild -list -project "$@" \
   | awk '/Schemes:/ { getline; print }' \
   | tr -d "\n "

--- a/bin/find_scheme.sh
+++ b/bin/find_scheme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+xcodebuild -list -project $@ \
+  | awk '/Schemes:/ { getline; print }' \
+  | tr -d "\n "

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -1,0 +1,49 @@
+command! XcodebuildBuild call <sid>build()
+command! XcodebuildTest call <sid>test()
+
+let s:plugin_path = expand("<sfile>:p:h:h")
+
+function! s:build()
+  let cmd = s:base_command()  . s:xcpretty()
+  call s:run_command(cmd)
+endfunction
+
+function! s:test()
+  let cmd =  s:base_command() . ' -sdk iphonesimulator test' . s:xcpretty()
+  call s:run_command(cmd)
+endfunction
+
+function! s:run_command(cmd)
+  echom a:cmd
+  execute '!' . a:cmd
+endfunction
+
+function! s:base_command()
+  return 'xcodebuild ' . s:build_target() . ' ' . s:scheme()
+endfunction
+
+function! s:build_target()
+  let xcworkspaceFile = globpath(expand('.'), '*.xcworkspace')
+  if empty(xcworkspaceFile)
+    return '-project ' . s:project_file()
+  else
+    return '-workspace ' . xcworkspaceFile
+  endif
+endfunction
+
+function! s:project_file()
+  return globpath(expand('.'), '*.xcodeproj')
+endfunction
+
+function! s:scheme()
+  let scheme = "silent ! 'sh " . s:plugin_path . "/bin/find_scheme.sh \"" . s:project_file() . "\""
+  return '-scheme '. scheme
+endfunction
+
+function! s:xcpretty()
+  if executable('xcpretty')
+    return ' | xcpretty --color --test'
+  else
+    return ''
+  endif
+endfunction

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -14,7 +14,6 @@ function! s:test()
 endfunction
 
 function! s:run_command(cmd)
-  echom a:cmd
   execute '!' . a:cmd
 endfunction
 

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -22,7 +22,7 @@ function! s:base_command()
 endfunction
 
 function! s:build_target()
-  let xcworkspaceFile = globpath(expand('.'), '*.xcworkspace')
+  let xcworkspaceFile = glob('*.xcworkspace')
   if empty(xcworkspaceFile)
     return '-project ' . s:project_file()
   else

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -35,7 +35,7 @@ function! s:project_file()
 endfunction
 
 function! s:scheme()
-  let scheme = "silent ! 'sh " . s:plugin_path . "/bin/find_scheme.sh \"" . s:project_file() . "\""
+  let scheme = "silent ! source " . s:plugin_path . "/bin/find_scheme.sh \"" . s:project_file() . "\""
   return '-scheme '. scheme
 endfunction
 


### PR DESCRIPTION
This is the first working version of this plugin. It allows you to
dynamically find the project or workspace, as well as dynamically
finding the first available scheme (looking only in the project).

It also has support for xcpretty, and dynamically adds it to the end of
the command if it's available.
