### PR TITLE
Let users customize the flags passed to xcpretty

### DIFF
--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -3,13 +3,21 @@ command! XcodebuildTest call <sid>test()
 
 let s:plugin_path = expand("<sfile>:p:h:h")
 
+if !exists("g:xcpretty_testing_flags")
+  let g:xcpretty_testing_flags = ""
+endif
+
+if !exists("g:xcpretty_flags")
+  let g:xcpretty_flags = "--color"
+endif
+
 function! s:build()
   let cmd = s:base_command()  . s:xcpretty()
   call s:run_command(cmd)
 endfunction
 
 function! s:test()
-  let cmd =  s:base_command() . ' -sdk iphonesimulator test' . s:xcpretty()
+  let cmd =  s:base_command() . ' -sdk iphonesimulator test' . s:xcpretty_test()
   call s:run_command(cmd)
 endfunction
 
@@ -41,8 +49,17 @@ endfunction
 
 function! s:xcpretty()
   if executable('xcpretty')
-    return ' | xcpretty --color'
+    return ' | xcpretty ' . g:xcpretty_flags
   else
     return ''
   endif
+endfunction
+
+function! s:xcpretty_test()
+  let xcpretty = s:xcpretty()
+  if empty(xcpretty)
+    return ''
+  endif
+
+  return xcpretty . ' ' . g:xcpretty_testing_flags
 endfunction

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -1,7 +1,7 @@
 command! XcodebuildBuild call <sid>build()
 command! XcodebuildTest call <sid>test()
 
-let s:plugin_path = expand("<sfile>:p:h:h")
+let s:plugin_path = expand('<sfile>:p:h:h')
 
 if !exists("g:xcpretty_testing_flags")
   let g:xcpretty_testing_flags = ""
@@ -43,7 +43,7 @@ function! s:project_file()
 endfunction
 
 function! s:scheme()
-  let scheme = system("source " . s:plugin_path . "/bin/find_scheme.sh \"" . s:project_file() . "\"")
+  let scheme = system('source ' . s:plugin_path . '/bin/find_scheme.sh "' . s:project_file() . '"')
   return '-scheme '. scheme
 endfunction
 

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -3,14 +3,6 @@ command! XcodebuildTest call <sid>test()
 
 let s:plugin_path = expand('<sfile>:p:h:h')
 
-if !exists("g:xcpretty_testing_flags")
-  let g:xcpretty_testing_flags = ""
-endif
-
-if !exists("g:xcpretty_flags")
-  let g:xcpretty_flags = "--color"
-endif
-
 function! s:build()
   let cmd = s:base_command()  . s:xcpretty()
   call s:run_command(cmd)
@@ -49,7 +41,7 @@ endfunction
 
 function! s:xcpretty()
   if executable('xcpretty')
-    return ' | xcpretty ' . g:xcpretty_flags
+    return ' | xcpretty ' . s:xcpretty_flags()
   else
     return ''
   endif
@@ -59,7 +51,23 @@ function! s:xcpretty_test()
   let xcpretty = s:xcpretty()
   if empty(xcpretty)
     return ''
+  else
+    return xcpretty . ' ' . s:xcpretty_testing_flags()
   endif
+endfunction
 
-  return xcpretty . ' ' . g:xcpretty_testing_flags
+function! s:xcpretty_flags()
+  if exists('g:xcodebuild_xcpretty_flags')
+    return g:xcodebuild_xcpretty_flags
+  else
+    return '--color'
+  endif
+endfunction
+
+function! s:xcpretty_testing_flags()
+  if exists('g:xcodebuild_xcpretty_testing_flags')
+    return g:xcodebuild_xcpretty_testing_flags
+  else
+    return ''
+  endif
 endfunction


### PR DESCRIPTION
This adds two variables that can be set to customize xcpretty:
- `xcpretty_flags` will be applied to all xcpretty operations. By
  default, this is set to `--color`.
- `xcpretty_testing_flags` will only be applied to test actions. This
  is empty by default.

fixes #7
