### PR TITLE
Ignore errors from xcodebuild when finding schemes

### DIFF
--- a/bin/find_scheme.sh
+++ b/bin/find_scheme.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+set -o pipefail
+
 xcodebuild -list -project "$@" 2>/dev/null \
   | awk '/Schemes:/ { getline; print }' \
   | tr -d "\n "

--- a/bin/find_scheme.sh
+++ b/bin/find_scheme.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 
-xcodebuild -list -project "$@" \
+xcodebuild -list -project "$@" 2>/dev/null \
   | awk '/Schemes:/ { getline; print }' \
   | tr -d "\n "


### PR DESCRIPTION
Fixes #6
