### PR TITLE
Cache scheme in a script variable

### DIFF
--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -35,8 +35,11 @@ function! s:project_file()
 endfunction
 
 function! s:scheme()
-  let scheme = system('source ' . s:plugin_path . '/bin/find_scheme.sh "' . s:project_file() . '"')
-  return '-scheme '. scheme
+  if !exists('s:chosen_scheme')
+    let s:chosen_scheme = system('source ' . s:plugin_path . '/bin/find_scheme.sh "' . s:project_file() . '"')
+  endif
+
+  return '-scheme '. s:chosen_scheme
 endfunction
 
 function! s:xcpretty()


### PR DESCRIPTION
This makes the plugin _much_ faster on subsequent runs, since
`xcodebuild -list` is impressively slow.

Fixes #4
