### PR TITLE
Simplify command names

### DIFF
--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -1,5 +1,5 @@
-command! XcodebuildBuild call <sid>build()
-command! XcodebuildTest call <sid>test()
+command! XBuild call <sid>build()
+command! XTest call <sid>test()
 
 let s:plugin_path = expand('<sfile>:p:h:h')
 


### PR DESCRIPTION
`XcodebuildBuild` and `XcodebuildTest` are _super_ long names,
especially if you need to keep typing them. In general, I expect these
to be assigned to a keybinding, but it's probably best to follow
fugitive's example here and make them more reasonable.
