### PR TITLE
Dynamically decide which sdk to test against

### DIFF
--- a/bin/use_simulator.sh
+++ b/bin/use_simulator.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+set -o pipefail
+
+project="$1"
+scheme="$2"
+
+xcodebuild -project "$project" -scheme "$scheme" -showBuildSettings \
+  | grep CORRESPONDING_SIMULATOR_SDK_NAME \
+  2>&1 > /dev/null

--- a/bin/use_simulator.sh
+++ b/bin/use_simulator.sh
@@ -1,10 +1,4 @@
 #!/usr/bin/env sh
 
-set -o pipefail
-
-project="$1"
-scheme="$2"
-
-xcodebuild -project "$project" -scheme "$scheme" -showBuildSettings \
-  | grep CORRESPONDING_SIMULATOR_SDK_NAME \
-  2>&1 > /dev/null
+xcodebuild -project "$1" -scheme "$2" -showBuildSettings 2>/dev/null \
+  | grep -q CORRESPONDING_SIMULATOR_SDK_NAME

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -3,6 +3,18 @@ command! XTest call <sid>test()
 
 let s:plugin_path = expand('<sfile>:p:h:h')
 
+function! s:bin_script(name)
+  return s:plugin_path . '/bin/' . a:name
+endfunction
+
+function! s:quoted(string)
+  return '"' . a:string . '"'
+endfunction
+
+function! s:cli_arg(string)
+  return ' ' . s:quoted(a:string)
+endfunction
+
 function! s:build()
   let cmd = s:base_command()  . s:xcpretty()
   call s:run_command(cmd)
@@ -36,7 +48,7 @@ endfunction
 
 function! s:scheme()
   if !exists('s:chosen_scheme')
-    let s:chosen_scheme = system('source ' . s:plugin_path . '/bin/find_scheme.sh "' . s:project_file() . '"')
+    let s:chosen_scheme = system('source ' . s:bin_script('find_scheme.sh') . s:cli_arg(s:project_file()))
   endif
 
   return '-scheme '. s:chosen_scheme

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -21,7 +21,7 @@ function! s:build()
 endfunction
 
 function! s:test()
-  let cmd =  s:base_command() . ' -sdk iphonesimulator test' . s:xcpretty_test()
+  let cmd =  s:base_command() . ' ' . s:sdk() . ' test' . s:xcpretty_test()
   call s:run_command(cmd)
 endfunction
 
@@ -47,11 +47,28 @@ function! s:project_file()
 endfunction
 
 function! s:scheme()
+  return '-scheme '. s:scheme_name()
+endfunction
+
+function!s:scheme_name()
   if !exists('s:chosen_scheme')
     let s:chosen_scheme = system('source ' . s:bin_script('find_scheme.sh') . s:cli_arg(s:project_file()))
   endif
 
-  return '-scheme '. s:chosen_scheme
+  return s:chosen_scheme
+endfunction
+
+function! s:sdk()
+  if !exists('s:use_simulator')
+    let _ = system('source ' . s:bin_script('use_simulator.sh') . s:cli_arg(s:project_file()) . s:cli_arg(s:scheme_name()))
+    let s:use_simulator = !v:shell_error
+  endif
+
+  if s:use_simulator
+    return '-sdk iphonesimulator'
+  else
+    return '-sdk macosx'
+  endif
 endfunction
 
 function! s:xcpretty()

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -11,8 +11,14 @@ function! s:quoted(string)
   return '"' . a:string . '"'
 endfunction
 
-function! s:cli_arg(string)
-  return ' ' . s:quoted(a:string)
+function! s:cli_args(...)
+  let cli_args = ''
+
+  for cli_arg in a:000
+    let cli_args = cli_args . ' ' . s:quoted(cli_arg)
+  endfor
+
+  return cli_args
 endfunction
 
 function! s:build()
@@ -52,7 +58,7 @@ endfunction
 
 function!s:scheme_name()
   if !exists('s:chosen_scheme')
-    let s:chosen_scheme = system('source ' . s:bin_script('find_scheme.sh') . s:cli_arg(s:project_file()))
+    let s:chosen_scheme = system('source ' . s:bin_script('find_scheme.sh') . s:cli_args(s:project_file()))
   endif
 
   return s:chosen_scheme
@@ -60,7 +66,7 @@ endfunction
 
 function! s:sdk()
   if !exists('s:use_simulator')
-    let _ = system('source ' . s:bin_script('use_simulator.sh') . s:cli_arg(s:project_file()) . s:cli_arg(s:scheme_name()))
+    let _ = system('source ' . s:bin_script('use_simulator.sh') . s:cli_args(s:project_file(), s:scheme_name()))
     let s:use_simulator = !v:shell_error
   endif
 

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -62,7 +62,7 @@ endfunction
 
 function! s:sdk()
   if !exists('s:use_simulator')
-    let _ = system('source ' . s:bin_script('use_simulator.sh') . s:cli_args(s:project_file(), s:scheme_name()))
+    call system('source ' . s:bin_script('use_simulator.sh') . s:cli_args(s:project_file(), s:scheme_name()))
     let s:use_simulator = !v:shell_error
   endif
 

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -7,15 +7,11 @@ function! s:bin_script(name)
   return s:plugin_path . '/bin/' . a:name
 endfunction
 
-function! s:quoted(string)
-  return '"' . a:string . '"'
-endfunction
-
 function! s:cli_args(...)
   let cli_args = ''
 
   for cli_arg in a:000
-    let cli_args = cli_args . ' ' . s:quoted(cli_arg)
+    let cli_args = cli_args . ' ' . shellescape(cli_arg)
   endfor
 
   return cli_args


### PR DESCRIPTION
If we're testing iOS apps, we want to specify the simulator, which means we
need to know if we're trying to test an iOS app or an OS X app.

In order to do so, we can just look at the output of
`xcodebuild -showBuildSettings` for the chosen project/scheme. If we see a
setting for `CORRESPONDING_SIMULATOR_SDK_NAME`, then we know it's an iOS
project, and can target the `iphonesimulator` sdk. To be safe, if we
_don't_ find that setting, we're pointing at the `macosx` sdk explicitly.

Fixes #9
