### PR TITLE
Use `map` to create the cli_args

### DIFF
--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -8,13 +8,7 @@ function! s:bin_script(name)
 endfunction
 
 function! s:cli_args(...)
-  let cli_args = ''
-
-  for cli_arg in a:000
-    let cli_args = cli_args . ' ' . shellescape(cli_arg)
-  endfor
-
-  return cli_args
+  return ' ' . join(map(copy(a:000), 'shellescape(v:val)'))
 endfunction
 
 function! s:build()


### PR DESCRIPTION
Turns out, vimscript has a _really_ wacky version of `map` for lists and
dictionaries. You can pass a list or a dict, and a string that will get
interpreted. Inside the string, you get access to `v:val` which is the
current value. The expression should return a string.

We then pass that through `join`, and prepend the whole thing with a
leading space.

Hat tip to @gabebw for pointing me in this direction. I'm all about them
functors.
