### PR TITLE
Allow the customization of the runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,32 @@ setting a couple of global variables in your `vimrc`:
  - `g:xcodebuild_xcpretty_test_flags` will be passed to test commands only. By
    default, this is empty.
 
+```vim
+let g:xcodebuild_xcpretty_flags = '--color --no-utf'
+let g:xcoebuild_xcpretty_test_flags = '--test'
+```
+
 See the [`xcpretty` formatting documentation][xcpretty-doc] for available
 options.
 
 [xcpretty-doc]: https://github.com/supermarin/xcpretty#formats
+
+### Async builds
+
+By default, `xcodebuild.vim` will take over the current terminal session to
+build and display the build/test log. However, with long build times, this
+might not be ideal. To help with this, `xcocebuild.vim` allows you to
+customize the runner by setting `g:xcodebuild_runner`:
+
+```vim
+let g:xcodebuild_runner = 'VtrSendCommandToRunner'
+```
+
+This is useful for using `xcodebuild.vim` with other plugins such as
+[`vim-tmux-runner`] and [`vim-dispatch`].
+
+[`vim-tmux-runner`]: https://github.com/christoomey/vim-tmux-runner
+[`vim-dispatch`]: https://github.com/tpope/vim-dispatch
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ options.
 
 By default, `xcodebuild.vim` will take over the current terminal session to
 build and display the build/test log. However, with long build times, this
-might not be ideal. To help with this, `xcocebuild.vim` allows you to
-customize the runner by setting `g:xcodebuild_runner`:
+might not be ideal. To help with this, `xcodebuild.vim` allows you to
+customize the runner by setting `g:xcodebuild_run_command`. This variable
+should be a template string, where `{cmd}` will be replaced by the
+`xcodebuild` command.
 
 ```vim
-let g:xcodebuild_runner = 'VtrSendCommandToRunner!'
+let g:xcodebuild_run_command = 'VtrSendCommandToRunner! {cmd}'
 ```
 
 This is useful for using `xcodebuild.vim` with other plugins such as

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ might not be ideal. To help with this, `xcocebuild.vim` allows you to
 customize the runner by setting `g:xcodebuild_runner`:
 
 ```vim
-let g:xcodebuild_runner = 'VtrSendCommandToRunner'
+let g:xcodebuild_runner = 'VtrSendCommandToRunner!'
 ```
 
 This is useful for using `xcodebuild.vim` with other plugins such as

--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -19,7 +19,7 @@ xcodebuild. By default, xcodebuild.vim passes the `--color` flag to xcpretty.
 CONFIGURATION                             *xcodebuild-configuration*
 
 * Set the runner to use for the xcodebuild command (uses ! by default)
- let g:xcodebuild_runner = 'VtrSendCommandToRunner!'
+ let g:xcodebuild_run_command = 'VtrSendCommandToRunner! {cmd}'
 
 * Set the flags passed to xcpretty for all actions, including test actions.
  let g:xcodebuild_xcpretty_flags = '--color'

--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -19,7 +19,7 @@ xcodebuild. By default, xcodebuild.vim passes the `--color` flag to xcpretty.
 CONFIGURATION                             *xcodebuild-configuration*
 
 * Set the runner to use for the xcodebuild command (uses ! by default)
- let g:xcodebuild_runner = 'VtrSendCommandToRunner'
+ let g:xcodebuild_runner = 'VtrSendCommandToRunner!'
 
 * Set the flags passed to xcpretty for all actions, including test actions.
  let g:xcodebuild_xcpretty_flags = '--color'

--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -18,6 +18,9 @@ xcodebuild. By default, xcodebuild.vim passes the `--color` flag to xcpretty.
 ==============================================================================
 CONFIGURATION                             *xcodebuild-configuration*
 
+* Set the runner to use for the xcodebuild command (uses ! by default)
+ let g:xcodebuild_runner = 'VtrSendCommandToRunner'
+
 * Set the flags passed to xcpretty for all actions, including test actions.
  let g:xcodebuild_xcpretty_flags = '--color'
 

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -1,7 +1,7 @@
 command! XBuild call <sid>build()
 command! XTest call <sid>test()
 
-let s:default_run_command = '!'
+let s:default_run_command = '! {cmd}'
 let s:default_xcpretty_flags = '--color'
 let s:default_xcpretty_testing_flags = ''
 
@@ -30,7 +30,8 @@ function! s:test()
 endfunction
 
 function! s:run_command(cmd)
-  execute s:runner() . ' ' . a:cmd
+  let run_cmd = substitute(s:runner_template(), '{cmd}', a:cmd, 'g')
+  execute run_cmd
 endfunction
 
 function! s:assert_project()
@@ -84,9 +85,9 @@ function! s:sdk()
   endif
 endfunction
 
-function! s:runner()
-  if exists('g:xcodebuild_runner')
-    return g:xcodebuild_runner
+function! s:runner_template()
+  if exists('g:xcodebuild_run_command')
+    return g:xcodebuild_run_command
   else
     return s:default_run_command
   endif

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -1,6 +1,10 @@
 command! XBuild call <sid>build()
 command! XTest call <sid>test()
 
+let s:default_run_command = '!'
+let s:default_xcpretty_flags = '--color'
+let s:default_xcpretty_testing_flags = ''
+
 let s:plugin_path = expand('<sfile>:p:h:h')
 
 function! s:bin_script(name)
@@ -84,7 +88,7 @@ function! s:runner()
   if exists('g:xcodebuild_runner')
     return g:xcodebuild_runner
   else
-    return '!'
+    return s:default_run_command
   endif
 endfunction
 
@@ -109,7 +113,7 @@ function! s:xcpretty_flags()
   if exists('g:xcodebuild_xcpretty_flags')
     return g:xcodebuild_xcpretty_flags
   else
-    return '--color'
+    return s:default_xcpretty_flags
   endif
 endfunction
 
@@ -117,6 +121,6 @@ function! s:xcpretty_testing_flags()
   if exists('g:xcodebuild_xcpretty_testing_flags')
     return g:xcodebuild_xcpretty_testing_flags
   else
-    return ''
+    return s:default_xcpretty_testing_flags
   endif
 endfunction

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -26,7 +26,7 @@ function! s:test()
 endfunction
 
 function! s:run_command(cmd)
-  execute '!' . a:cmd
+  execute s:runner() . ' ' . a:cmd
 endfunction
 
 function! s:assert_project()
@@ -77,6 +77,14 @@ function! s:sdk()
     return '-sdk iphonesimulator'
   else
     return '-sdk macosx'
+  endif
+endfunction
+
+function! s:runner()
+  if exists('g:xcodebuild_runner')
+    return g:xcodebuild_runner
+  else
+    return '!'
   endif
 endfunction
 


### PR DESCRIPTION
This makes it dead simple to customize xcodebuild.vim so that it works
with other libs such as vim-tmux-runner and vim-dispatch

https://github.com/christoomey/vim-tmux-runner
https://github.com/tpope/vim-dispatch

ping @christoomey because I'm referencing his fantastic library and want to
make sure I'm representing/using it properly.

Fixes #18 
