### PR TITLE
Add XSelectScheme command

### DIFF
--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -10,7 +10,8 @@ CONTENTS                                                 *xcodebuild-Contents*
       2. Usage ......................... |xcodebuild-Usage|
         2.1  ............................. |xcodebuild-:XBuild|
         2.2  ............................. |xcodebuild-:XTest|
-        2.3  ............................. |xcodebuild-xcpretty|
+        2.3  ............................. |xcodebuild-:XSelectScheme|
+        2.4  ............................. |xcodebuild-xcpretty|
       3. Configuration ................. |xcodebuild-Configuration|
         3.1 .............................. |xcodebuild_run_command|
         3.2 .............................. |xcodebuild_xcpretty_flags|
@@ -72,8 +73,18 @@ previously). This information is cached with the Vim session, so subsequent
 runs will execute faster.
 
 ------------------------------------------------------------------------------
+                                                    *xcodebuild-:XSelectScheme*
+2.3 :XSelectScheme~
+
+Set the scheme to build or test through `xcodebuild`.
+
+Specify the scheme to build or test. Calling this command resets the currently
+set SDK to build with. If you set a scheme that doesn't exist, `xcodebuild`
+will throw an error.
+
+------------------------------------------------------------------------------
                                                           *xcodebuild-xcpretty*
-2.3 xcpretty~
+2.4 xcpretty~
 
 If `xcpretty`[1] is installed and is available in your `$PATH`,
 `xcodebuild.vim` will pipe all output through it to improve `xcodebuild`'s

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -1,5 +1,6 @@
 command! XBuild call <sid>build()
 command! XTest call <sid>test()
+command! -nargs=1 XSelectScheme call <sid>set_scheme("<args>")
 
 let s:default_run_command = '! {cmd}'
 let s:default_xcpretty_flags = '--color'
@@ -27,6 +28,11 @@ function! s:test()
     let cmd =  s:base_command() . ' ' . s:sdk() . ' test' . s:xcpretty_test()
     call s:run_command(cmd)
   endif
+endfunction
+
+function! s:set_scheme(scheme)
+  let s:chosen_scheme = a:scheme
+  unlet! s:use_simulator
 endfunction
 
 function! s:run_command(cmd)
@@ -64,7 +70,7 @@ function! s:scheme()
   return '-scheme '. s:scheme_name()
 endfunction
 
-function!s:scheme_name()
+function! s:scheme_name()
   if !exists('s:chosen_scheme')
     let s:chosen_scheme = system('source ' . s:bin_script('find_scheme.sh') . s:cli_args(s:project_file()))
   endif


### PR DESCRIPTION
This command allows users to switch the scheme being built. When doing
so we also reset the current SDK in case the scheme targets a different
OS.

I pushed the xcpretty docs down since it made sense to group commands together. If you'd prefer this not change let me know and I can swap them.

I also didn't write much for the help since there's not a lot to this command, let me know if there's anything else I should include.
