### PR TITLE
Use custom build directory

### DIFF
--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -15,8 +15,9 @@ CONTENTS                                                 *xcodebuild-Contents*
         2.5  ............................. |xcodebuild-xcpretty|
       3. Configuration ................. |xcodebuild-Configuration|
         3.1 .............................. |xcodebuild_run_command|
-        3.2 .............................. |xcodebuild_xcpretty_flags|
-        3.3 .............................. |xcodebuild_xcpretty_testing_flags|
+        3.2 .............................. |xcodebuild_build_dir|
+        3.3 .............................. |xcodebuild_xcpretty_flags|
+        3.4 .............................. |xcodebuild_xcpretty_testing_flags|
 
 ==============================================================================
 ABOUT (1)                                                    *xcodebuild-About*
@@ -129,8 +130,18 @@ Default: '! {cmd}`
 [5]: https://github.com/tpope/vim-dispatch
 
 ------------------------------------------------------------------------------
+                                                       *xcodebuild_build_dir*
+3.1 g:xcodebuild_build_dir~
+
+Set the build location.
+
+  let g:xcodebuild_build_dir = './my_custom_build_location'
+
+Default: './build'
+
+------------------------------------------------------------------------------
                                                     *xcodebuild_xcpretty_flags*
-3.2 g:xcodebuild_xcpretty_flags~
+3.3 g:xcodebuild_xcpretty_flags~
 
 The flags to pass to `xcpretty`[1] for all actions, including tests.
 
@@ -144,7 +155,7 @@ Default: '--color'
 
 ------------------------------------------------------------------------------
                                             *xcodebuild_xcpretty_testing_flags*
-3.3 g:xcodebuild_xcpretty_testing_flags~
+3.4 g:xcodebuild_xcpretty_testing_flags~
 
 The flags to pass to `xcpretty`[1] for test actions only.
 

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -4,6 +4,7 @@ command! XClean call <sid>clean()
 command! -nargs=1 XSelectScheme call <sid>set_scheme("<args>")
 
 let s:default_run_command = '! {cmd}'
+let s:default_build_dir = './build'
 let s:default_xcpretty_flags = '--color'
 let s:default_xcpretty_testing_flags = ''
 
@@ -58,7 +59,17 @@ function! s:assert_project()
 endfunction
 
 function! s:base_command()
-  return 'xcodebuild ' . s:build_target() . ' ' . s:scheme()
+  return 'xcodebuild ' . s:build_dir() . ' ' . s:build_target() . ' ' . s:scheme()
+endfunction
+
+function! s:build_dir()
+  if exists('g:xcodebuild_build_dir')
+    let build_dir = g:xcodebuild_build_dir
+  else
+    let build_dir = s:default_build_dir
+  endif
+
+  return 'CONFIGURATION_BUILD_DIR=' . build_dir
 endfunction
 
 function! s:build_target()


### PR DESCRIPTION
Instead of using the build directory defined by Xcode, we can override it
and build in the current directory. The benefit here is that in the
_future_, we can use this command to build the project and then use
`simctl` to load the app in the iOS simulator. That's not something we can
do using the default build location (AFAIK).

In addition, we can let users customize this location with a global
variable. By default, we'll build in `./build`, but if users want to send
the build to a different location, they can do that easily.

This feels like it might be a little weird. But the pros here are that this
disconnects us entirely from Xcode's build artifacts, and it means that
creating a command like `:XRun` will be easier, because we'll know exactly
where the build app is.
