### PR TITLE
Run xcodebuild with unbuffered output

### DIFF
--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -71,7 +71,7 @@ function! s:assert_project()
 endfunction
 
 function! s:base_command()
-  return 'xcodebuild ' . s:build_dir() . ' ' . s:build_target() . ' ' . s:scheme() . ' ' . s:sdk()
+  return 'xcodebuild NSUnbufferedIO=YES ' . s:build_dir() . ' ' . s:build_target() . ' ' . s:scheme() . ' ' . s:sdk()
 endfunction
 
 function! s:build_dir()


### PR DESCRIPTION
Original explanation:
https://github.com/fastlane/scan/commit/a6aea8c8f8980a6faceb51466316cf55316feba6

Original text:
When xcodebuild is piped (even through a simple `cat`) the test results
output becomes buffered. This is very annoying when piped through
xcpretty because the test results only appear once all the tests have
run.

Setting the `NSUnbufferedIO` environment variable to `YES` when running
xcodebuild solves this issue, see:
http://stackoverflow.com/questions/18995187/xcodebuild-corrupts-test-result-output-when-output-redirected-to-file/19190226#comment54275017_19190226

I'm unclear on if there's a downside to always having this set.
