### PR TITLE
Added initial escaping for schemes

### DIFF
--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -98,7 +98,7 @@ function! s:project_file()
 endfunction
 
 function! s:scheme()
-  return '-scheme '. s:scheme_name()
+  return '-scheme \"'. s:scheme_name() . '\"'
 endfunction
 
 function! s:scheme_name()


### PR DESCRIPTION
This should help a bit with issue 27. This was enough to get my schemes in the form of "Project iOS" / "Project Mac" to build and test.
