### PR TITLE
Don't override build directory

### DIFF
--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -17,9 +17,8 @@ CONTENTS                                                 *xcodebuild-Contents*
         2.7  ............................. |xcodebuild-xcpretty|
       3. Configuration ................. |xcodebuild-Configuration|
         3.1 .............................. |xcodebuild_run_command|
-        3.2 .............................. |xcodebuild_build_dir|
-        3.3 .............................. |xcodebuild_xcpretty_flags|
-        3.4 .............................. |xcodebuild_xcpretty_testing_flags|
+        3.2 .............................. |xcodebuild_xcpretty_flags|
+        3.3 .............................. |xcodebuild_xcpretty_testing_flags|
 
 ==============================================================================
 ABOUT (1)                                                    *xcodebuild-About*
@@ -154,18 +153,8 @@ Default: '! {cmd}`
 [5]: https://github.com/tpope/vim-dispatch
 
 ------------------------------------------------------------------------------
-                                                       *xcodebuild_build_dir*
-3.1 g:xcodebuild_build_dir~
-
-Set the build location.
-
-  let g:xcodebuild_build_dir = './my_custom_build_location'
-
-Default: './build'
-
-------------------------------------------------------------------------------
                                                     *xcodebuild_xcpretty_flags*
-3.3 g:xcodebuild_xcpretty_flags~
+3.2 g:xcodebuild_xcpretty_flags~
 
 The flags to pass to `xcpretty`[1] for all actions, including tests.
 
@@ -179,7 +168,7 @@ Default: '--color'
 
 ------------------------------------------------------------------------------
                                             *xcodebuild_xcpretty_testing_flags*
-3.4 g:xcodebuild_xcpretty_testing_flags~
+3.3 g:xcodebuild_xcpretty_testing_flags~
 
 The flags to pass to `xcpretty`[1] for test actions only.
 

--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -6,7 +6,6 @@ command! -nargs=1 -complete=file XSwitch call <sid>switch("<args>")
 command! -nargs=1 XSelectScheme call <sid>set_scheme("<args>")
 
 let s:default_run_command = '! {cmd}'
-let s:default_build_dir = './build'
 let s:default_xcpretty_flags = '--color'
 let s:default_xcpretty_testing_flags = ''
 
@@ -71,17 +70,7 @@ function! s:assert_project()
 endfunction
 
 function! s:base_command()
-  return 'xcodebuild NSUnbufferedIO=YES ' . s:build_dir() . ' ' . s:build_target() . ' ' . s:scheme() . ' ' . s:sdk()
-endfunction
-
-function! s:build_dir()
-  if exists('g:xcodebuild_build_dir')
-    let build_dir = g:xcodebuild_build_dir
-  else
-    let build_dir = s:default_build_dir
-  endif
-
-  return 'CONFIGURATION_BUILD_DIR=' . build_dir
+  return 'xcodebuild NSUnbufferedIO=YES ' . s:build_target() . ' ' . s:scheme() . ' ' . s:sdk()
 endfunction
 
 function! s:build_target()


### PR DESCRIPTION
We were overriding this in order to support a future feature (the
ability to run an app from Vim), but this also broke the ability for
`xcodebuild` to find implicit dependencies.

I think it's worthwhile to remove this from the codebase and try to find
another option for supporting a run command when we get to that.

Fixes #32
