### PR TITLE
Add more shell escaping when passing args

### DIFF
--- a/plugin/xcodebuild.vim
+++ b/plugin/xcodebuild.vim
@@ -76,9 +76,9 @@ endfunction
 function! s:build_target()
   let xcworkspaceFile = glob('*.xcworkspace')
   if empty(xcworkspaceFile)
-    return '-project ' . s:project_file()
+    return '-project' . s:cli_args(s:project_file())
   else
-    return '-workspace ' . xcworkspaceFile
+    return '-workspace' . s:cli_args(xcworkspaceFile)
   endif
 endfunction
 
@@ -87,7 +87,7 @@ function! s:project_file()
 endfunction
 
 function! s:scheme()
-  return '-scheme '. s:scheme_name()
+  return '-scheme'. s:cli_args(s:scheme_name())
 endfunction
 
 function! s:scheme_name()


### PR DESCRIPTION
Previously we were just passing the project, workspace, and scheme to
the command line completely unescaped. This isn't super safe. Instead,
we should pass all of these through our `cli_args` function to add
quotes and a leading space for everything that's passed to the command
line.

Fixes #27

Hat tip to @stack for the original implementation in
https://github.com/gfontenot/vim-xcodebuild/pull/34
