### PR TITLE
Allow users to specify a file to open with XOpen

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ its own. It dynamically finds the project in the current working directory
  - `:XBuild` will build the project
  - `:XTest` will test the project
  - `:XClean` will clean the project's build directory
- - `:XOpen` will open the project in Xcode
+ - `:XOpen` will open the project or a specified file in Xcode
  - `:XSwitch` will switch the selected version of Xcode (requires sudo)
  - `:XSelectScheme` will let you manually specify the scheme to build and test
 

--- a/bin/open_project.sh
+++ b/bin/open_project.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
 xcode=$(xcode-select -p | sed 's|/Contents/Developer||')
-open -a "$xcode" .
+open -a "$xcode" "$1"

--- a/doc/xcode.txt
+++ b/doc/xcode.txt
@@ -89,12 +89,21 @@ occasionally solve these issues.
                                                                   *xcode-:XOpen*
 2.4 :XOpen~
 
-Open the project in Xcode
+Open the project or a specified file in Xcode
 
 There are still some things that aren't able to be done in Vim. Things like
 modifying the project index, changing build settings, and working with
 Interface Builder are better done in Xcode. This command provides an easy way
 to open the project quickly.
+
+You can also pass an optional file path to this command in order to open that
+file in Xcode. This can be useful for doing things like debugging a tricky
+class with the help of Xcode's faster feedback loop, or modifying an interface
+file.
+
+Xcode itself is fairly smart about this, too. If you open a specific file
+while you have the project itself open, Xcode will actually just open the
+specified file inside the already-open project.
 
 ------------------------------------------------------------------------------
                                                                 *xcode-:XSwitch*

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -1,7 +1,7 @@
 command! XBuild call <sid>build()
 command! XTest call <sid>test()
 command! XClean call <sid>clean()
-command! XOpen call <sid>open()
+command! -nargs=? -complete=file XOpen call <sid>open("<args>")
 command! -nargs=1 -complete=file XSwitch call <sid>switch("<args>")
 command! -nargs=1 XSelectScheme call <sid>set_scheme("<args>")
 
@@ -40,9 +40,14 @@ function! s:clean()
   endif
 endfunction
 
-function! s:open()
+function! s:open(path)
   if s:assert_project()
-    call system('source ' . s:bin_script('open_project.sh'))
+    if empty(a:path)
+      let file_path = "."
+    else
+      let file_path = a:path
+    endif
+    call system('source ' . s:bin_script('open_project.sh') . s:cli_args(file_path))
   endif
 endfunction
 


### PR DESCRIPTION
Instead of opening the full project every time, it can be really useful
to open a specific file in Xcode. For example, if you're having trouble
debugging a specific class and you want Xcode's faster feedback loop, or
if you want to open a storyboard in Xcode for editing.

This modifies the `XOpen` command so that it can take an optional
argument. If that argument is provided, it will open the specified file
in Xcode. If the argument is omitted, it will open the entire project.

Note that Xcode itself is fairly smart about this. If you already have
the project open, for example, it will open the specified file _inside
the open project_, instead of opening a new window. This is handy.

Fixes #42
