### PR TITLE
Allow users to change the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ its own. It dynamically finds the project in the current working directory
  - `:XClean` will clean the project's build directory
  - `:XOpen` will open the project or a specified file in Xcode
  - `:XSwitch` will switch the selected version of Xcode (requires sudo)
+ - `:XSelectProject` will let you manually specify the project to build and
+   test
  - `:XSelectScheme` will let you manually specify the scheme to build and test
 
 ### `xcpretty` support

--- a/doc/xcode.txt
+++ b/doc/xcode.txt
@@ -13,8 +13,9 @@ CONTENTS                                                        *xcode-Contents*
         2.3  ............................. |xcode-:XClean|
         2.4  ............................. |xcode-:XOpen|
         2.5  ............................. |xcode-:XSwitch|
-        2.6  ............................. |xcode-:XSelectScheme|
-        2.7  ............................. |xcode-xcpretty|
+        2.6  ............................. |xcode-:XSelectProject|
+        2.7  ............................. |xcode-:XSelectScheme|
+        2.8  ............................. |xcode-xcpretty|
       3. Configuration ................. |xcode-Configuration|
         3.1 .............................. |xcode_run_command|
         3.2 .............................. |xcode_xcpretty_flags|
@@ -117,8 +118,18 @@ outside of Vim with `xcode-select`, but it's useful to have a quick shortcut
 for accessing that functionality quickly.
 
 ------------------------------------------------------------------------------
+                                                         *xcode-:XSelectProject*
+2.6 :XSelectProject~
+
+Set the project to build or test through `xcodebuild`.
+
+Specify the project to build or test. Calling this command resets the
+currently set SDK to build with, as well as the selected scheme. If you set a
+project that doesn't exist, `xcodebuild` will throw an error.
+
+------------------------------------------------------------------------------
                                                           *xcode-:XSelectScheme*
-2.6 :XSelectScheme~
+2.7 :XSelectScheme~
 
 Set the scheme to build or test through `xcodebuild`.
 
@@ -128,7 +139,7 @@ will throw an error.
 
 ------------------------------------------------------------------------------
                                                                 *xcode-xcpretty*
-2.7 xcpretty~
+2.8 xcpretty~
 
 If `xcpretty`[1] is installed and is available in your `$PATH`, `xcode.vim`
 will pipe all output through it to improve `xcodebuild`'s output. See

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -3,6 +3,7 @@ command! XTest call <sid>test()
 command! XClean call <sid>clean()
 command! -nargs=? -complete=file XOpen call <sid>open("<args>")
 command! -nargs=1 -complete=file XSwitch call <sid>switch("<args>")
+command! -nargs=1 -complete=file XSelectProject call <sid>set_project("<args>")
 command! -nargs=1 XSelectScheme call <sid>set_scheme("<args>")
 
 let s:default_run_command = '! {cmd}'
@@ -55,6 +56,12 @@ function! s:switch(target)
   execute '!sudo xcode-select -s' . s:cli_args(a:target)
 endfunction
 
+function! s:set_project(project)
+  let s:chosen_project = a:project
+  unlet! s:chosen_scheme
+  unlet! s:use_simulator
+endfunction
+
 function! s:set_scheme(scheme)
   let s:chosen_scheme = a:scheme
   unlet! s:use_simulator
@@ -88,7 +95,11 @@ function! s:build_target()
 endfunction
 
 function! s:project_file()
-  return globpath(expand('.'), '*.xcodeproj')
+  if !exists('s:chosen_project')
+    let s:chosen_project = split(globpath(expand('.'), '*.xcodeproj'), '\n')[0]
+  endif
+
+  return s:chosen_project
 endfunction
 
 function! s:scheme()


### PR DESCRIPTION
Previously, we were naively assuming a single xcode project at the root of
the project repo. Obviously, this was a dumb assumption. If a user had
multiple projects at the same level, we'd end up sending all of them to the
commands expecting a project name. This broke the commands and it wasn't
possible to recover.

To fix this, we can follow the same pattern we used for selecting the
schemes. We can check to see if the user has selected a project on first
run, and if not we can supply a reasonable default. As with the scheme,
we'll default to the first one we see.
