### PR TITLE
Allow users to provide default projects/schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,31 @@ its own. It dynamically finds the project in the current working directory
    test
  - `:XSelectScheme` will let you manually specify the scheme to build and test
 
+### Project and Scheme configuration
+
+If `xcode.vim` is having trouble determining the project/scheme to use, you
+can set local variables to manually specify the configuration you expect:
+
+```
+let g:xcode_project_file = 'path/to/project.xcodeproj'
+let g:xcode_default_scheme = 'MyScheme'
+```
+
+Note that manually specifying a different project or scheme with the
+`:XSelectProject` or `:XSelectScheme` commands will override these values
+until you restart vim.
+
+This is most useful when placed inside a project-specific vimrc ([See the Argo
+vimrc as an example][argo-vimrc]). You can make sure Vim loads these local
+vimrc files by default by setting the following in your main vimrc:
+
+[argo-vimrc]: https://github.com/thoughtbot/Argo/blob/master/.vimrc
+
+```
+set secure  " Don't let external configs do scary shit
+set exrc    " Load local vimrc if found
+```
+
 ### `xcpretty` support
 
 [`xcpretty`] is a gem for improving the output of xcodebuild. By default, if

--- a/doc/xcode.txt
+++ b/doc/xcode.txt
@@ -20,6 +20,8 @@ CONTENTS                                                        *xcode-Contents*
         3.1 .............................. |xcode_run_command|
         3.2 .............................. |xcode_xcpretty_flags|
         3.3 .............................. |xcode_xcpretty_testing_flags|
+        3.4 .............................. |xcode_project_file|
+        3.5 .............................. |xcode_default_scheme|
 
 ==============================================================================
 ABOUT (1)                                                          *xcode-About*
@@ -204,6 +206,33 @@ See the `xcpretty` documentation[6] for available options.
 Default: ''
 
 [6]: https://github.com/supermarin/xcpretty#formats
+
+------------------------------------------------------------------------------
+                                                            *xcode_project_file*
+3.4 g:xcode_project_file~
+
+The main project to use for building and testing.
+
+If `xcode.vim` routinely selects the wrong project, you can set this local
+variable to tell it which to use. This is useful if you have multiple projects
+at the root of your project and the one you would like to default to isn't the
+first alphabetically.
+
+If not set, `xcode.vim` will default to the first project file it finds
+alphabetically.
+
+------------------------------------------------------------------------------
+                                                          *xcode_default_scheme*
+3.5 g:xcode_default_scheme~
+
+The default scheme to use for building and testing.
+
+If `xcode.vim` routinely selects the wrong scheme, you can set this local
+variable to tell it which to use. This is useful if you have multiple schemes
+in your project, and they are occasionally reordered.
+
+If not set, `xcode.vim` will default to the first scheme listed as a result of
+`xcodebuild -list`
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -96,7 +96,11 @@ endfunction
 
 function! s:project_file()
   if !exists('s:chosen_project')
-    let s:chosen_project = split(globpath(expand('.'), '*.xcodeproj'), '\n')[0]
+    if exists('g:xcode_project_file')
+      let s:chosen_project = g:xcode_project_file
+    else
+      let s:chosen_project = split(globpath(expand('.'), '*.xcodeproj'), '\n')[0]
+    endif
   endif
 
   return s:chosen_project
@@ -108,7 +112,11 @@ endfunction
 
 function! s:scheme_name()
   if !exists('s:chosen_scheme')
-    let s:chosen_scheme = system('source ' . s:bin_script('find_scheme.sh') . s:cli_args(s:project_file()))
+    if exists('g:xcode_default_scheme')
+      let s:chosen_scheme = g:xcode_default_scheme
+    else
+      let s:chosen_scheme = system('source ' . s:bin_script('find_scheme.sh') . s:cli_args(s:project_file()))
+    endif
   endif
 
   return s:chosen_scheme


### PR DESCRIPTION
Previously, if xcode.vim was selecting the wrong scheme or project, the only
thing you could do was to correct the selection for the lifetime of the
current session. This meant that you'd have to reset those values every time
you opened vim. This is fairly annoying.

To fix this, we can first check for the existence of a global variable before
choosing our own default. If it's there, we can then use that instead of
trying to infer which to use. If it isn't we can still fall back to a sane
default.

Fixes #47 I think
