### PR TITLE
Add custom autocomplete for projects and schemes

### DIFF
--- a/bin/list_schemes.sh
+++ b/bin/list_schemes.sh
@@ -3,5 +3,6 @@
 set -o pipefail
 
 xcodebuild -list -project "$@" 2>/dev/null \
-  | awk '/Schemes:/ { getline; print }' \
-  | tr -d "\n "
+  | awk '/Schemes:/,0' \
+  | tail -n +2 \
+  | sed -e "s/^[[:space:]]*//"


### PR DESCRIPTION
Previously, we were just allowing users to type anything into the scheme
selection command without any kind of hint about what was available. This
sucked. Additionally, we were autocompleting for projects, but we were
autocompleting for all files in the current directory. Both of these things
meant it was super easy to screw up and enter a scheme or project that didn't
exist.

To fix this, we can add some custom autocompletion scripts to our plugin. For
XSelectProject, we can autocomplete based on all available project files in
the current directory. Easy peasy. And for schemes, we can modify our
`find_scheme.sh` script to instead list available schemes and then cache that
in memory to use for autocompletion.

Fixes #24
Fixes #49
