### PR TITLE
Add `:Xrun` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,25 @@ its own. It dynamically finds the project in the current working directory
  - `:Xclean` will clean the project's build directory
  - `:Xopen` will open the project or a specified file in Xcode
  - `:Xswitch` will switch the selected version of Xcode (requires sudo)
- - `:Xproject` will let you manually specify the project to build and
-   test
+ - `:Xworkspace` will let you manually specify the workspace to build and test
+ - `:Xproject` will let you manually specify the project to build and test
  - `:Xscheme` will let you manually specify the scheme to build and test
 
 ### Project and Scheme configuration
 
-If `xcode.vim` is having trouble determining the project/scheme to use, you
-can set local variables to manually specify the configuration you expect:
+If `xcode.vim` is having trouble determining the workspace/project/scheme to
+use, you can set local variables to manually specify the configuration you
+expect:
 
 ```
+let g:xcode_workspace_file = 'path/to/workspace.xcworkspace'
 let g:xcode_project_file = 'path/to/project.xcodeproj'
 let g:xcode_default_scheme = 'MyScheme'
 ```
 
 Note that manually specifying a different project or scheme with the
-`:Xproject` or `:Xscheme` commands will override these values until you
-restart vim.
+`:Xworkspace`, `:Xproject`, or `:Xscheme` commands will override these values
+until you restart vim.
 
 This is most useful when placed inside a project-specific vimrc ([See the Argo
 vimrc as an example][argo-vimrc]). You can make sure Vim loads these local

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ its own. It dynamically finds the project in the current working directory
 (with support for workspaces as well) and builds the first scheme it finds.
 
  - `:Xbuild` will build the project
- - `:Xrun` will run the app in the iOS Simulator
+ - `:Xrun` will run the app in the iOS Simulator or locally on your Mac
  - `:Xtest` will test the project
  - `:Xclean` will clean the project's build directory
  - `:Xopen` will open the project or a specified file in Xcode

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ its own. It dynamically finds the project in the current working directory
 (with support for workspaces as well) and builds the first scheme it finds.
 
  - `:Xbuild` will build the project
+ - `:Xrun` will run the app in the iOS Simulator
  - `:Xtest` will test the project
  - `:Xclean` will clean the project's build directory
  - `:Xopen` will open the project or a specified file in Xcode

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ from within Vim).
 By default, `xcode.vim` will take over the current terminal session to build
 and display the build/test log. However, with long build times, this might not
 be ideal. To help with this, `xcode.vim` allows you to customize the runner by
-setting `g:xcode_run_command`. This variable should be a template string,
+setting `g:xcode_runner_command`. This variable should be a template string,
 where `{cmd}` will be replaced by the `xcodebuild` command.
 
 ```vim
-let g:xcode_run_command = 'VtrSendCommandToRunner! {cmd}'
+let g:xcode_runner_command = 'VtrSendCommandToRunner! {cmd}'
 ```
 
 This is useful for using `xcode.vim` with other plugins such as

--- a/bin/run_ios_app
+++ b/bin/run_ios_app
@@ -3,11 +3,11 @@
 device_type="iPhone 6s"
 
 build_path=$(xcodebuild -showBuildSettings $@ 2>/dev/null | egrep "\bBUILD_DIR\b" | sed -E "s/[[:space:]]+BUILD_DIR = //")
-app_path=$(find $build_path -iname "*.app" | head -n1)
+app_path=$(find "$build_path" -iname "*.app" | head -n1)
 app_id=$(defaults read "$app_path/Info" "CFBundleIdentifier")
 uuid=$(xcrun simctl list devices | grep "$device_type" | head -n1 | grep -E "[0-9A-F-]{8,}" -o)
 
-xcrun instruments -w $uuid 2>/dev/null
+xcrun instruments -w "$uuid" 2>/dev/null
 
-xcrun simctl install booted $app_path
-xcrun simctl launch booted $app_id
+xcrun simctl install booted "$app_path"
+xcrun simctl launch booted "$app_id"

--- a/bin/run_ios_app
+++ b/bin/run_ios_app
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+device_type="iPhone 6s"
+
+build_path=$(xcodebuild -showBuildSettings $@ 2>/dev/null | egrep "\bBUILD_DIR\b" | sed -E "s/[[:space:]]+BUILD_DIR = //")
+app_path=$(find $build_path -iname "*.app" | head -n1)
+app_id=$(defaults read "$app_path/Info" "CFBundleIdentifier")
+uuid=$(xcrun simctl list devices | grep "$device_type" | head -n1 | grep -E "[0-9A-F-]{8,}" -o)
+
+xcrun instruments -w $uuid 2>/dev/null
+
+xcrun simctl install booted $app_path
+xcrun simctl launch booted $app_id

--- a/bin/run_mac_app
+++ b/bin/run_mac_app
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+build_path=$(xcodebuild -showBuildSettings $@ 2>/dev/null | egrep "\bBUILD_DIR\b" | sed -E "s/[[:space:]]+BUILD_DIR = //")
+app_path=$(find "$build_path" -iname "*.app" | head -n1)
+
+open "$app_path"

--- a/doc/xcode.txt
+++ b/doc/xcode.txt
@@ -73,7 +73,7 @@ with your Vim session, so subsequent runs will execute faster.
                                                                    *xcode-:Xrun*
 2.2 :Xrun
 
-Run the built app in the simulator.
+Run the built app in the iOS simulator or locally on your Mac.
 
 This command requires that the project had previously been built with
 |:Xbuild|.

--- a/doc/xcode.txt
+++ b/doc/xcode.txt
@@ -19,7 +19,7 @@ CONTENTS                                                        *xcode-Contents*
         2.9  ............................. |xcode-:Xscheme|
         2.10 ............................. |xcode-xcpretty|
       3. Configuration ................. |xcode-Configuration|
-        3.1 .............................. |xcode_run_command|
+        3.1 .............................. |xcode_runner_command|
         3.2 .............................. |xcode_xcpretty_flags|
         3.3 .............................. |xcode_xcpretty_testing_flags|
         3.4 .............................. |xcode_workspace_file|
@@ -176,8 +176,8 @@ CONFIGURATION (3)                                          *xcode-Configuration*
 You can configure `xcode.vim` with the following settings:
 
 ------------------------------------------------------------------------------
-                                                             *xcode_run_command*
-3.1 g:xcode_run_command~
+                                                          *xcode_runner_command*
+3.1 g:xcode_runner_command~
 
 The command to use when executing `xcodebuild` commands.
 
@@ -189,7 +189,7 @@ You can customize this if you want to pass the command through a custom script
 in your `$PATH`, or use something like `vim-tmux-runner`[4] or
 `vim-dispatch`[5] to make builds asynchronous
 
-  let g:xcode_run_command = 'VtrSendCommandToRunner! {cmd}'
+  let g:xcode_runner_command = 'VtrSendCommandToRunner! {cmd}'
 
 Default: '! {cmd}`
 

--- a/doc/xcode.txt
+++ b/doc/xcode.txt
@@ -9,14 +9,15 @@ CONTENTS                                                        *xcode-Contents*
       1. About.......................... |xcode-About|
       2. Usage ......................... |xcode-Usage|
         2.1  ............................. |xcode-:Xbuild|
-        2.2  ............................. |xcode-:Xtest|
-        2.3  ............................. |xcode-:Xclean|
-        2.4  ............................. |xcode-:Xopen|
-        2.5  ............................. |xcode-:Xswitch|
-        2.6  ............................. |xcode-:Xworkspace|
-        2.7  ............................. |xcode-:Xproject|
-        2.8  ............................. |xcode-:Xscheme|
-        2.9  ............................. |xcode-xcpretty|
+        2.2  ............................. |xcode-:Xrun|
+        2.3  ............................. |xcode-:Xtest|
+        2.4  ............................. |xcode-:Xclean|
+        2.5  ............................. |xcode-:Xopen|
+        2.6  ............................. |xcode-:Xswitch|
+        2.7  ............................. |xcode-:Xworkspace|
+        2.8  ............................. |xcode-:Xproject|
+        2.9  ............................. |xcode-:Xscheme|
+        2.10 ............................. |xcode-xcpretty|
       3. Configuration ................. |xcode-Configuration|
         3.1 .............................. |xcode_run_command|
         3.2 .............................. |xcode_xcpretty_flags|
@@ -69,8 +70,17 @@ parses the scheme information from the project. This scheme info is cached
 with your Vim session, so subsequent runs will execute faster.
 
 ------------------------------------------------------------------------------
+                                                                   *xcode-:Xrun*
+2.2 :Xrun
+
+Run the built app in the simulator.
+
+This command requires that the project had previously been built with
+|:Xbuild|.
+
+------------------------------------------------------------------------------
                                                                   *xcode-:Xtest*
-2.2 :Xtest~
+2.3 :Xtest~
 
 Run the project tests through `xcodebuild`.
 
@@ -82,7 +92,7 @@ runs will execute faster.
 
 ------------------------------------------------------------------------------
                                                                  *xcode-:Xclean*
-2.3 :Xclean~
+2.4 :Xclean~
 
 Clean the project's build directory with `xcodebuild`
 
@@ -92,7 +102,7 @@ occasionally solve these issues.
 
 ------------------------------------------------------------------------------
                                                                   *xcode-:Xopen*
-2.4 :Xopen~
+2.5 :Xopen~
 
 Open the project or a specified file in Xcode
 
@@ -112,7 +122,7 @@ specified file inside the already-open project.
 
 ------------------------------------------------------------------------------
                                                                 *xcode-:Xswitch*
-2.5 :Xswitch~
+2.6 :Xswitch~
 
 Switch the selected version of Xcode with `xcode-select`.
 
@@ -123,7 +133,7 @@ for accessing that functionality quickly.
 
 ------------------------------------------------------------------------------
                                                              *xcode-:Xworkspace*
-2.6 :Xworkspace~
+2.7 :Xworkspace~
 
 Set the workspace to build or test through `xcodebuild`.
 
@@ -133,7 +143,7 @@ workspace that doesn't exist, `xcodebuild` will throw an error.
 
 ------------------------------------------------------------------------------
                                                                *xcode-:Xproject*
-2.7 :Xproject~
+2.8 :Xproject~
 
 Set the project to build or test through `xcodebuild`.
 
@@ -143,7 +153,7 @@ project that doesn't exist, `xcodebuild` will throw an error.
 
 ------------------------------------------------------------------------------
                                                                 *xcode-:Xscheme*
-2.8 :Xscheme~
+2.9 :Xscheme~
 
 Set the scheme to build or test through `xcodebuild`.
 
@@ -153,7 +163,7 @@ will throw an error.
 
 ------------------------------------------------------------------------------
                                                                 *xcode-xcpretty*
-2.9 xcpretty~
+2.10 xcpretty~
 
 If `xcpretty`[1] is installed and is available in your `$PATH`, `xcode.vim`
 will pipe all output through it to improve `xcodebuild`'s output. See

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -14,7 +14,7 @@ command! -nargs=1 -complete=custom,s:list_projects
 command! -nargs=1 -complete=custom,s:list_workspaces
       \ Xworkspace call <sid>set_workspace("<args>")
 
-let s:default_run_command = '! {cmd}'
+let s:default_runner_command = '! {cmd}'
 let s:default_xcpretty_flags = '--color'
 let s:default_xcpretty_testing_flags = ''
 
@@ -214,10 +214,10 @@ function! s:osx_destination()
 endfunction
 
 function! s:runner_template()
-  if exists('g:xcode_run_command')
-    return g:xcode_run_command
+  if exists('g:xcode_runner_command')
+    return g:xcode_runner_command
   else
-    return s:default_run_command
+    return s:default_runner_command
   endif
 endfunction
 

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -37,7 +37,7 @@ endfunction
 
 function s:run()
   if s:assert_project()
-    let cmd =  s:bin_script('run_ios_app') . ' ' . s:build_target_with_scheme()
+    let cmd = s:run_command()
     call s:execute_command(cmd)
   endif
 endfunction
@@ -106,6 +106,22 @@ endfunction
 
 function! s:base_command()
   return 'xcodebuild NSUnbufferedIO=YES ' . s:build_target() . ' ' . s:scheme()
+endfunction
+
+function! s:run_command()
+  if s:use_simulator()
+    return s:iphone_simulator_run_command()
+  else
+    return s:mac_run_command()
+  endif
+endfunction
+
+function! s:iphone_simulator_run_command()
+  return s:bin_script('run_ios_app') . ' ' . s:build_target_with_scheme()
+endfunction
+
+function! s:mac_run_command()
+  return s:bin_script('run_mac_app') . ' ' . s:build_target_with_scheme()
 endfunction
 
 function! s:build_target_with_scheme()

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -31,28 +31,28 @@ endfunction
 function! s:build()
   if s:assert_project()
     let cmd = s:base_command() . ' ' . s:destination() . s:xcpretty()
-    call s:run_command(cmd)
+    call s:execute_command(cmd)
   endif
 endfunction
 
 function s:run()
   if s:assert_project()
     let cmd =  s:bin_script('run_ios_app') . ' ' . s:build_target_with_scheme()
-    call s:run_command(cmd)
+    call s:execute_command(cmd)
   endif
 endfunction
 
 function! s:test()
   if s:assert_project()
     let cmd =  s:base_command() . ' ' . s:destination() . ' test' . s:xcpretty_test()
-    call s:run_command(cmd)
+    call s:execute_command(cmd)
   endif
 endfunction
 
 function! s:clean()
   if s:assert_project()
     let cmd = s:base_command() . ' clean' . s:xcpretty()
-    call s:run_command(cmd)
+    call s:execute_command(cmd)
   endif
 endfunction
 
@@ -90,7 +90,7 @@ function! s:set_scheme(scheme)
   unlet! s:use_simulator
 endfunction
 
-function! s:run_command(cmd)
+function! s:execute_command(cmd)
   let run_cmd = substitute(s:runner_template(), '{cmd}', a:cmd, 'g')
   execute run_cmd
 endfunction

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -1,4 +1,5 @@
 command! Xbuild call <sid>build()
+command! Xrun call <sid>run()
 command! Xtest call <sid>test()
 command! Xclean call <sid>clean()
 command! -nargs=? -complete=file Xopen call <sid>open("<args>")
@@ -30,6 +31,13 @@ endfunction
 function! s:build()
   if s:assert_project()
     let cmd = s:base_command() . ' ' . s:destination() . s:xcpretty()
+    call s:run_command(cmd)
+  endif
+endfunction
+
+function s:run()
+  if s:assert_project()
+    let cmd =  s:bin_script('run_ios_app') . ' ' . s:build_target_with_scheme()
     call s:run_command(cmd)
   endif
 endfunction

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -96,7 +96,7 @@ function! s:execute_command(cmd)
 endfunction
 
 function! s:assert_project()
-  if empty(s:project_file()) && empty(s:workspace_file())
+  if empty(s:project_files()) && empty(s:workspace_files())
     echohl ErrorMsg | echo 'No Xcode project file found!' | echohl None
     return 0
   else
@@ -113,7 +113,7 @@ function! s:build_target_with_scheme()
 endfunction
 
 function! s:build_target()
-  if empty(s:workspace_file())
+  if empty(s:workspace_files())
     return '-project' . s:cli_args(s:project_file())
   else
     return '-workspace' . s:cli_args(s:workspace_file())


### PR DESCRIPTION
:tada:

This is awesome. `:Xrun` will run your iOS apps in the iOS simulator, and run
your mac apps locally. Right now it's running the commands with your runner
command. I think it's probably worth changing this for the long-term, but I
want to get this functionality in now.

Fixes #22
