### PR TITLE
Add the ability to pass actions to Xbuild

### DIFF
--- a/doc/xcode.txt
+++ b/doc/xcode.txt
@@ -69,6 +69,10 @@ The first time this command is run, there will be a small delay as the plugin
 parses the scheme information from the project. This scheme info is cached
 with your Vim session, so subsequent runs will execute faster.
 
+You can also optionally pass build actions to |:Xbuild| if you'd like to
+override the default of `build`. This could be used, for example, to run
+`xcodebuild clean build` if you wanted to clean before building.
+
 ------------------------------------------------------------------------------
                                                                    *xcode-:Xrun*
 2.2 :Xrun

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -105,7 +105,7 @@ function! s:assert_project()
 endfunction
 
 function! s:base_command()
-  return 'xcodebuild NSUnbufferedIO=YES ' . s:build_target() . ' ' . s:scheme()
+  return 'NSUnbufferedIO=YES xcrun xcodebuild ' . s:build_target_with_scheme()
 endfunction
 
 function! s:run_command()

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -117,7 +117,8 @@ function! s:assert_project()
 endfunction
 
 function! s:base_command(actions)
-  return 'NSUnbufferedIO=YES xcrun xcodebuild '
+  return 'set -o pipefail; '
+        \ . 'NSUnbufferedIO=YES xcrun xcodebuild '
         \ . a:actions
         \ . ' '
         \ . s:build_target_with_scheme()


### PR DESCRIPTION
It's reasonable to think that users might want to run commands other than just
a simple `build` command. To make this easy, we can change the Xbuild command
so that it accepts actions to perform, defaulting to `build` if none are
provided. This means if you need to you could run `:Xbuild clean build<CR>`
and it'd clean and build. It also means you could run any action supported by
xcodebuild itself. I suppose it also means you could abuse the command to pass
_any_ options to xcodebuild that you want, but we'll autocomplete to the
actions to try guiding people in the right direction.
