### PR TITLE
Allow users to specify the simulator to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ Plugin for building and testing Xcode projects from within Vim
 
 ## Installation
 
-Recommended installation with [vundle](https://github.com/gmarik/vundle):
+If you don't have a preferred installation method check out
+[vim-plug](https://github.com/junegunn/vim-plug):
 
 ```vim
-Plugin 'gfontenot/vim-xcode'
+Plug 'gfontenot/vim-xcode'
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ its own. It dynamically finds the project in the current working directory
  - `:Xclean` will clean the project's build directory
  - `:Xopen` will open the project or a specified file in Xcode
  - `:Xswitch` will switch the selected version of Xcode (requires sudo)
- - `:Xworkspace` will let you manually specify the workspace to build and test
- - `:Xproject` will let you manually specify the project to build and test
- - `:Xscheme` will let you manually specify the scheme to build and test
+ - `:Xworkspace` will let you manually specify the workspace
+ - `:Xproject` will let you manually specify the project
+ - `:Xscheme` will let you manually specify the scheme
+ - `:Xsimulator` will let you manually specify the simulator
 
-### Project and Scheme configuration
+### Default Configuration
 
 If `xcode.vim` is having trouble determining the workspace/project/scheme to
 use, you can set local variables to manually specify the configuration you
@@ -39,9 +40,14 @@ let g:xcode_project_file = 'path/to/project.xcodeproj'
 let g:xcode_default_scheme = 'MyScheme'
 ```
 
-Note that manually specifying a different project or scheme with the
-`:Xworkspace`, `:Xproject`, or `:Xscheme` commands will override these values
-until you restart vim.
+You can also specify a custom default simulator to use:
+
+```
+let g:xcode_default_simulator = 'iPhone 5'
+```
+
+Note that manually specifying a different value with any of the setter
+commands listed above will override these values until you restart Vim.
 
 This is most useful when placed inside a project-specific vimrc ([See the Argo
 vimrc as an example][argo-vimrc]). You can make sure Vim loads these local

--- a/bin/list_available_simulators.sh
+++ b/bin/list_available_simulators.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+set -o pipefail
+
+xcrun simctl list devicetypes \
+  | tail -n +2 \
+  | sed -E "s/[[:space:]]\(.*$//"

--- a/bin/run_ios_app
+++ b/bin/run_ios_app
@@ -1,11 +1,9 @@
 #!/usr/bin/env sh
 
-device_type="iPhone 6s"
-
 build_path=$(xcodebuild -showBuildSettings $@ 2>/dev/null | egrep "\bBUILD_DIR\b" | sed -E "s/[[:space:]]+BUILD_DIR = //")
 app_path=$(find "$build_path" -iname "*.app" | head -n1)
 app_id=$(defaults read "$app_path/Info" "CFBundleIdentifier")
-uuid=$(xcrun simctl list devices | grep "$device_type" | head -n1 | grep -E "[0-9A-F-]{8,}" -o)
+uuid=$(xcrun simctl list devices | grep "$SIMULATOR" | head -n1 | grep -E "[0-9A-F-]{8,}" -o)
 
 xcrun instruments -w "$uuid" 2>/dev/null
 

--- a/doc/xcode.txt
+++ b/doc/xcode.txt
@@ -17,7 +17,8 @@ CONTENTS                                                        *xcode-Contents*
         2.7  ............................. |xcode-:Xworkspace|
         2.8  ............................. |xcode-:Xproject|
         2.9  ............................. |xcode-:Xscheme|
-        2.10 ............................. |xcode-xcpretty|
+        2.10 ............................. |xcode-:Xsimulator|
+        2.11 ............................. |xcode-xcpretty|
       3. Configuration ................. |xcode-Configuration|
         3.1 .............................. |xcode_runner_command|
         3.2 .............................. |xcode_xcpretty_flags|
@@ -25,6 +26,7 @@ CONTENTS                                                        *xcode-Contents*
         3.4 .............................. |xcode_workspace_file|
         3.5 .............................. |xcode_project_file|
         3.6 .............................. |xcode_default_scheme|
+        3.7 .............................. |xcode_default_simulator|
 
 ==============================================================================
 ABOUT (1)                                                          *xcode-About*
@@ -81,6 +83,11 @@ Run the built app in the iOS simulator or locally on your Mac.
 
 This command requires that the project had previously been built with
 |:Xbuild|.
+
+You can also optionally pass a simulator name to |:Xrun| if you'd like to
+override the default for this specific session. Note that if the app was build
+for a different architecture than the specified simulator, the simulator will
+fail to launch.
 
 ------------------------------------------------------------------------------
                                                                   *xcode-:Xtest*
@@ -166,8 +173,17 @@ set SDK to build with. If you set a scheme that doesn't exist, `xcodebuild`
 will throw an error.
 
 ------------------------------------------------------------------------------
+                                                             *xcode-:Xsimulator*
+2.10 :Xsimulator~
+
+Set the simulator to use for building/testing/running.
+
+This will set the simulator to use for all commands while Xcode is running. It
+will be reset to the default value (`"iPhone 6s"`) when Vim restarts.
+
+------------------------------------------------------------------------------
                                                                 *xcode-xcpretty*
-2.10 xcpretty~
+2.11 xcpretty~
 
 If `xcpretty`[1] is installed and is available in your `$PATH`, `xcode.vim`
 will pipe all output through it to improve `xcodebuild`'s output. See
@@ -273,6 +289,17 @@ in your project, and they are occasionally reordered.
 
 If not set, `xcode.vim` will default to the first scheme listed as a result of
 `xcodebuild -list`
+
+------------------------------------------------------------------------------
+                                                       *xcode_default_simulator*
+3.6 g:xcode_default_simulator~
+
+The default simulator to use for building/testing/running.
+
+If you'd like to make sure that you use a specific device by default every
+time you build/run/test your iOS app, you can set this variable to do so.
+
+If not set, `xcode.vim` will default to `"iPhone 6s"`
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
You can specify the simulator to build/test/run against in three ways:
- Setting `g:xcode_default_simulator` will set the simulator for all commands
  to the specified value when vim launches.
- Setting the simulator with `Xsimulator` will set the simulator for all
  commands while vim is running. It will be reset if vim restarts.
- Specifying the simulator along with `Xrun` will use the specified simulator
  for that one run command. Note that if the app was built for a different
  architecture than the specified simulator, the simulator will fail to
  launch.
