### PR TITLE
Quote $@ to avoid reexpansion

### DIFF
--- a/bin/list_schemes.sh
+++ b/bin/list_schemes.sh
@@ -2,7 +2,7 @@
 
 set -o pipefail
 
-xcrun xcodebuild -list $@ 2>/dev/null \
+xcrun xcodebuild -list "$@" 2>/dev/null \
   | awk '/Schemes:/,0' \
   | tail -n +2 \
   | sed -e "s/^[[:space:]]*//"

--- a/bin/run_ios_app
+++ b/bin/run_ios_app
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-build_path=$(xcodebuild -showBuildSettings $@ 2>/dev/null | egrep "\bBUILD_DIR\b" | sed -E "s/[[:space:]]+BUILD_DIR = //")
+build_path=$(xcodebuild -showBuildSettings "$@" 2>/dev/null | egrep "\bBUILD_DIR\b" | sed -E "s/[[:space:]]+BUILD_DIR = //")
 app_path=$(find "$build_path" -iname "*.app" | head -n1)
 app_id=$(defaults read "$app_path/Info" "CFBundleIdentifier")
 uuid=$(xcrun simctl list devices | grep "$SIMULATOR" | head -n1 | grep -E "[0-9A-F-]{8,}" -o)

--- a/bin/run_mac_app
+++ b/bin/run_mac_app
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-build_path=$(xcodebuild -showBuildSettings $@ 2>/dev/null | egrep "\bBUILD_DIR\b" | sed -E "s/[[:space:]]+BUILD_DIR = //")
+build_path=$(xcodebuild -showBuildSettings "$@" 2>/dev/null | egrep "\bBUILD_DIR\b" | sed -E "s/[[:space:]]+BUILD_DIR = //")
 app_path=$(find "$build_path" -iname "*.app" | head -n1)
 
 open "$app_path"

--- a/bin/use_simulator.sh
+++ b/bin/use_simulator.sh
@@ -2,5 +2,5 @@
 
 set -o pipefail
 
-xcrun xcodebuild -showBuildSettings $@ 2>/dev/null \
+xcrun xcodebuild -showBuildSettings "$@" 2>/dev/null \
   | grep -q CORRESPONDING_SIMULATOR_SDK_NAME


### PR DESCRIPTION
Turns out we need to quote `%@` in shell scripts in order to preserve quotes
that are passed in. I had no idea. Without the quotes, projects, workspaces,
and schemes with spaces in them would cause weird opaque errors.

Many thanks to @gabebw for pointing this out.
http://gabebw.com/blog/2015/11/29/command-line-arguments-in-shell-scripts

Fixes #55
Fixes #60
