### PR TITLE
Improve platform detection

### DIFF
--- a/bin/project_platform.sh
+++ b/bin/project_platform.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+sim_info=$(xcrun xcodebuild -showBuildSettings "$@" 2>/dev/null \
+  | grep CORRESPONDING_SIMULATOR_SDK_NAME)
+
+if [[ "$sim_info" == *"appletv"* ]]; then
+  platform="tvos"
+elif [[ "$sim_info" == *"watch"*  ]]; then
+  platform="watchos"
+elif [[ "$sim_info" == *"iphone"* ]]; then
+  platform="ios"
+else
+  platform="macos"
+fi
+
+printf "$platform"

--- a/bin/use_simulator.sh
+++ b/bin/use_simulator.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env sh
-
-set -o pipefail
-
-xcrun xcodebuild -showBuildSettings "$@" 2>/dev/null \
-  | grep -q CORRESPONDING_SIMULATOR_SDK_NAME

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -267,8 +267,8 @@ endfunction
 
 function! s:use_simulator()
   if !exists('s:use_simulator')
-    call system('source ' . s:bin_script('use_simulator.sh') . ' ' . s:build_target_with_scheme())
-    let s:use_simulator = !v:shell_error
+    let platform = system('source ' . s:bin_script('project_platform.sh') . ' ' . s:build_target_with_scheme())
+    let s:use_simulator = platform ==# "ios"
   endif
 
   return s:use_simulator


### PR DESCRIPTION
Right now we're not doing anything with this, but in the future we can
probably use this platform information to be smarter about default simulators
as well as allowing users to build tvOS and watch apps.
