### PR TITLE
Xrun should also build the app

### DIFF
--- a/doc/xcode.txt
+++ b/doc/xcode.txt
@@ -79,15 +79,10 @@ override the default of `build`. This could be used, for example, to run
                                                                    *xcode-:Xrun*
 2.2 :Xrun
 
-Run the built app in the iOS simulator or locally on your Mac.
-
-This command requires that the project had previously been built with
-|:Xbuild|.
+Build and run the app in the iOS simulator or locally on your Mac.
 
 You can also optionally pass a simulator name to |:Xrun| if you'd like to
-override the default for this specific session. Note that if the app was build
-for a different architecture than the specified simulator, the simulator will
-fail to launch.
+override the default for this specific session.
 
 ------------------------------------------------------------------------------
                                                                   *xcode-:Xtest*


### PR DESCRIPTION
This is obvious in hindsight, but instead of forcing users to build manually
and then run as a separate step we should instead build _and_ run when the
user invokes `Xrun`. This _greatly_ simplifies the UI and is much more
intuitive.

Note that this meant refactoring the commands so that we're always passing the
preferred simulator from the top down. For _most_ of the commands, it doesn't
really matter, but for `Xrun` we want to make sure that we're building and
running with the same settings consistently.

Fixes #68
