### PR TITLE
Fix issue where device builds would be installed in the simulator

### DIFF
--- a/bin/run_ios_app
+++ b/bin/run_ios_app
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-build_path=$(xcodebuild -showBuildSettings "$@" 2>/dev/null | egrep "\bBUILD_DIR\b" | sed -E "s/[[:space:]]+BUILD_DIR = //")
+build_path=$(xcodebuild -showBuildSettings "$@" 2>/dev/null | sed -nE "s/^[[:space:]]+CONFIGURATION_BUILD_DIR = //p")
 app_path=$(find "$build_path" -iname "*.app" | head -n1)
 app_id=$(defaults read "$app_path/Info" "CFBundleIdentifier")
 uuid=$(xcrun simctl list devices | grep "$SIMULATOR" | head -n1 | grep -E "[0-9A-F-]{8,}" -o)

--- a/doc/xcode.txt
+++ b/doc/xcode.txt
@@ -27,6 +27,7 @@ CONTENTS                                                        *xcode-Contents*
         3.5 .............................. |xcode_project_file|
         3.6 .............................. |xcode_default_scheme|
         3.7 .............................. |xcode_default_simulator|
+        3.8 .............................. |xcode_default_configuration|
 
 ==============================================================================
 ABOUT (1)                                                          *xcode-About*
@@ -287,7 +288,7 @@ If not set, `xcode.vim` will default to the first scheme listed as a result of
 
 ------------------------------------------------------------------------------
                                                        *xcode_default_simulator*
-3.6 g:xcode_default_simulator~
+3.7 g:xcode_default_simulator~
 
 The default simulator to use for building/testing/running.
 
@@ -295,6 +296,18 @@ If you'd like to make sure that you use a specific device by default every
 time you build/run/test your iOS app, you can set this variable to do so.
 
 If not set, `xcode.vim` will default to `"iPhone 6s"`
+
+------------------------------------------------------------------------------
+                                                   *xcode_default_configuration*
+3.8 g:xcode_default_configuration~
+
+The default build configuration to use for building/testing/running.
+
+If you'd like to make sure that you use a specific build configuration by
+default every time you build/run/test your iOS app, you can set this variable
+to do so.
+
+If not set, `xcode.vim` will default to `"Debug"`
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -162,6 +162,8 @@ function! s:iphone_simulator_run_command(simulator)
         \ . s:bin_script('run_ios_app')
         \ . ' '
         \ . s:build_target_with_options()
+        \ . ' '
+        \ . s:iphone_simulator_sdk()
 endfunction
 
 function! s:mac_run_command()
@@ -307,6 +309,10 @@ endfunction
 
 function! s:iphone_simulator_destination(simulator)
   return '-destination "platform=iOS Simulator,name=' . a:simulator . '"'
+endfunction
+
+function! s:iphone_simulator_sdk()
+  return '-sdk iphonesimulator'
 endfunction
 
 function! s:osx_destination()


### PR DESCRIPTION
Fixes #66.

This is one possible solution to resolve an issue where device builds would be installed in the simulator, and then crash on launch because they are built for the wrong architecture.

The main problem I have with this as a potential solution is that we now completely ignore the configuration set in the scheme, in favour of an explicit configuration variable managed by vim-xcode.

However, the only alternative I've been able to think of is to add code to first locate and then parse .xcscheme files, so that we can then communicate various scheme parameters to `xcodebuild -showBuildSettings` and `simctl launch`. This is possibly a little complicated, because it would involve writing logic to try and locate the correct xcscheme file to use. Parsing itself would be less complicated because we should be able to extract values with some straightforward XPath queries and something like `xmllint`.

Love to know what you think of this approach, and whether we should just go for supporting more features of Xcode schemes.
