### PR TITLE
Add Neovim support

### DIFF
--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -21,7 +21,12 @@ command! -nargs=1 -complete=custom,s:list_workspaces
 command! -nargs=1 -complete=custom,s:list_simulators
       \ Xsimulator call <sid>set_simulator("<args>")
 
-let s:default_runner_command = '! {cmd}'
+if has('nvim')
+  let s:default_runner_command = 'terminal {cmd}'
+else
+  let s:default_runner_command = '! {cmd}'
+endif
+
 let s:default_xcpretty_flags = '--color'
 let s:default_xcpretty_testing_flags = ''
 let s:default_simulator = 'iPhone 6s'
@@ -94,7 +99,13 @@ function! s:open(path)
 endfunction
 
 function! s:switch(target)
-  execute '!sudo xcode-select -s' . s:cli_args(a:target)
+  if has('nvim')
+    let runner = '!'
+  else
+    let runner = 'terminal'
+  endif
+
+  execute runner . ' sudo xcode-select -s' . s:cli_args(a:target)
 endfunction
 
 function! s:set_workspace(workspace)


### PR DESCRIPTION
Neovim removed `!` as a command (I believe), and replaced it with a built-in
terminal emulator. This adds support for Neovim in the most basic way
possible, which is to default to `terminal` instead of `!` when we're using
Neovim.

We're also switching out the runner for `s:switch` because of the same issue.
