### PR TITLE
Fix invalid expression in s:set_simulator()

### DIFF
--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -117,7 +117,7 @@ function! s:set_scheme(scheme)
 endfunction
 
 function! s:set_simulator(simulator)
-  let s:chosen_simulator = a:'simulator
+  let s:chosen_simulator = a:simulator
 endfunction
 
 function! s:execute_command(cmd)


### PR DESCRIPTION
This was causing the following error when using `:Xsimulator`:

```
E15: Invalid expression: a:'simulator
```
