### PR TITLE
Use native lists

### DIFF
--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -189,7 +189,7 @@ function! s:workspace_file()
     if exists('g:xcode_workspace_file')
       let s:chosen_workspace = g:xcode_workspace_file
     else
-      let s:chosen_workspace = split(s:workspace_files(), '\n')[0]
+      let s:chosen_workspace = s:workspace_files()[0]
     endif
   endif
 
@@ -201,7 +201,7 @@ function! s:list_workspaces(a, l, f)
 endfunction
 
 function! s:workspace_files()
-  return globpath(expand('.'), '*.xcworkspace')
+  return globpath(expand('.'), '*.xcworkspace', 0, 1)
 endfunction
 
 function! s:project_file()
@@ -209,7 +209,7 @@ function! s:project_file()
     if exists('g:xcode_project_file')
       let s:chosen_project = g:xcode_project_file
     else
-      let s:chosen_project = split(s:project_files(), '\n')[0]
+      let s:chosen_project = s:project_files()[0]
     endif
   endif
 
@@ -221,7 +221,7 @@ function! s:list_projects(a, l, f)
 endfunction
 
 function! s:project_files()
-  return globpath(expand('.'), '*.xcodeproj')
+  return globpath(expand('.'), '*.xcodeproj', 0, 1)
 endfunction
 
 function! s:scheme()

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -1,7 +1,7 @@
 command! -nargs=? -complete=customlist,s:build_actions
       \ Xbuild call <sid>build("<args>")
 
-command! -nargs=? -complete=custom,s:list_simulators
+command! -nargs=? -complete=customlist,s:list_simulators
       \ Xrun call <sid>run("<args>")
 
 command! Xtest call <sid>test()
@@ -9,7 +9,7 @@ command! Xclean call <sid>clean()
 command! -nargs=? -complete=file Xopen call <sid>open("<args>")
 command! -nargs=1 -complete=file Xswitch call <sid>switch("<args>")
 
-command! -nargs=1 -complete=custom,s:list_schemes
+command! -nargs=1 -complete=customlist,s:list_schemes
       \ Xscheme call <sid>set_scheme("<args>")
 
 command! -nargs=1 -complete=custom,s:list_projects
@@ -18,7 +18,7 @@ command! -nargs=1 -complete=custom,s:list_projects
 command! -nargs=1 -complete=custom,s:list_workspaces
       \ Xworkspace call <sid>set_workspace("<args>")
 
-command! -nargs=1 -complete=custom,s:list_simulators
+command! -nargs=1 -complete=customlist,s:list_simulators
       \ Xsimulator call <sid>set_simulator("<args>")
 
 function! s:system_runner()
@@ -233,7 +233,7 @@ function! s:scheme_name()
     if exists('g:xcode_default_scheme')
       let s:chosen_scheme = g:xcode_default_scheme
     else
-      let s:chosen_scheme = split(s:schemes(), '\n')[0]
+      let s:chosen_scheme = s:schemes()[0]
     endif
   endif
 
@@ -246,7 +246,7 @@ endfunction
 
 function! s:schemes()
   if !exists('s:available_schemes')
-    let s:available_schemes = system('source ' . s:bin_script('list_schemes.sh') . ' ' . s:build_target())
+    let s:available_schemes = systemlist('source ' . s:bin_script('list_schemes.sh') . ' ' . s:build_target())
   endif
 
   return s:available_schemes
@@ -270,7 +270,7 @@ endfunction
 
 function! s:available_simulators()
   if !exists('s:simulators')
-    let s:simulators = system('source ' . s:bin_script('list_available_simulators.sh'))
+    let s:simulators = systemlist('source ' . s:bin_script('list_available_simulators.sh'))
   endif
 
   return s:simulators


### PR DESCRIPTION
`systemlist` and `globpath` both allow us to use native VimL lists, instead of
needing to parse strings ourselves. Cool stuff.
