### PR TITLE
Tail logs after running

### DIFF
--- a/bin/run_ios_app
+++ b/bin/run_ios_app
@@ -9,3 +9,4 @@ xcrun instruments -w "$uuid" 2>/dev/null
 
 xcrun simctl install booted "$app_path"
 xcrun simctl launch booted "$app_id"
+tail -f "$HOME/Library/Logs/CoreSimulator/$uuid/system.log"


### PR DESCRIPTION
Right now, we're just printing the pid for the app process after running.
That's not particularly useful, and I often find myself needing to open Xcode
just to use the app in the simulator.

I think there's more we could do here, but for right now, it probably makes
sense to at _least_ tail the logs for the simulator wherever we ran the run
command. It's at least a more useful default behavior than doing nothing.
