### PR TITLE
Run iOS apps in an lldb session

### DIFF
--- a/bin/run_ios_app
+++ b/bin/run_ios_app
@@ -1,11 +1,26 @@
 #!/usr/bin/env sh
 
+tmpdir="$(mktemp -dt "$(basename "$0")")"
+trap "rm -rf $tmpdir" EXIT
+
 build_path=$(xcodebuild -showBuildSettings "$@" 2>/dev/null | egrep "\bBUILD_DIR\b" | sed -E "s/[[:space:]]+BUILD_DIR = //")
 app_path=$(find "$build_path" -iname "*.app" | head -n1)
 app_id=$(defaults read "$app_path/Info" "CFBundleIdentifier")
+executable_name=$(defaults read "$app_path/Info" "CFBundleExecutable")
+executable_path="$app_path/$executable_name"
+lldb_script_path="$tmpdir/launch_ios_app.lldb"
 uuid=$(xcrun simctl list devices | grep "$SIMULATOR" | head -n1 | grep -E "[0-9A-F-]{8,}" -o)
 
 xcrun instruments -w "$uuid" 2>/dev/null
 
 xcrun simctl install booted "$app_path"
-xcrun simctl launch booted "$app_id"
+
+cat >"$lldb_script_path" <<EOF
+process launch -s
+b -[UIApplication _run]
+continue
+platform shell xcrun simctl launch booted $app_id
+continue
+EOF
+
+lldb -f "$executable_path" -s "$lldb_script_path"


### PR DESCRIPTION
Getting an lldb session running in the simulator is a two-step process:
1. The binary itself must be launched from within lldb in order to capture the processes output streams.
2. Once the binary is launched, the app must then be "launched" from within the simulator. This doesn't actually create a new process, but instead brings the app into the foreground of the simulator, and is analogous to tapping on the app icon.

Because of the order of these steps, the `xcrun simctl launch` command has to be run from with the lldb session.

Because lldb won't normally accept further commands after `process launch`, we use the `-s` argument to have the app pause just after starting (like stopping at a breakpoint). However, running `xcrun simctl launch` at this very early stage (before `main` has even executed) causes a separate instance of the app to start up in the simulator.

In order to work around this we set a breakpoint on `-[UIApplication _run]`, which is early enough that the application hasn't actually started yet, but after `UIApplicationMain` has set everything up and started the main run loop. Breaking here is a safe place to shell out to `xcrun simctl launch`, which will no longer start a separte process because the app is already "running".

The other quirk is that in order to feed commands to lldb we need to use the `-s` option, which requires a file. So the launch script is written to a temporary file first so that it can be passed to lldb. Bash process substitution may also work (e.g., `<(cat "$script")`).
