### PR TITLE
Improve project detection

### DIFF
--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -135,8 +135,24 @@ function! s:execute_command(cmd)
 endfunction
 
 function! s:assert_project()
-  if empty(s:project_files()) && empty(s:workspace_files())
+  if s:project_exists() || s:workspace_exists()
+    return 1
+  else
     echohl ErrorMsg | echo 'No Xcode project file found!' | echohl None
+    return 0
+  endif
+endfunction
+
+function! s:project_exists()
+  if empty(s:project_files()) && !exists('g:xcode_project_file')
+    return 0
+  else
+    return 1
+  endif
+endfunction
+
+function! s:workspace_exists()
+  if empty(s:workspace_files()) && !exists('g:xcode_workspace_file')
     return 0
   else
     return 1


### PR DESCRIPTION
Previously, we were only using the projects/workspaces in the root of
the project repo to determine if we could run our Xcode commands. This
made sense for the most part but also meant that if you explicitly
declared a path to an Xcode project/workspace and it _wasn't_ in the
root, we wouldn't let you run these commands. This made working with
non-standard project layouts (like those in React Native projects)
difficult to work with.

To fix this, we can refactor our project/workspace detection to take
the explicit file paths into account. If you're explicitly defining a
project path and it doesn't exist, I feel like that's your fault and you
deserve what you get.