### PR TITLE
Open specified project if available

### DIFF
--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -193,10 +193,10 @@ function! s:build_target_with_scheme()
 endfunction
 
 function! s:build_target()
-  if empty(s:workspace_files())
-    return '-project' . s:cli_args(s:project_file())
-  else
+  if s:workspace_exists()
     return '-workspace' . s:cli_args(s:workspace_file())
+  else
+    return '-project' . s:cli_args(s:project_file())
   endif
 endfunction
 

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -94,7 +94,11 @@ endfunction
 function! s:open(path)
   if s:assert_project()
     if empty(a:path)
-      let file_path = "."
+      if s:workspace_exists()
+        let file_path = s:workspace_file()
+      else
+        let file_path = s:project_file()
+      endif
     else
       let file_path = a:path
     endif


### PR DESCRIPTION
Instead of opening `.` with Xcode (which just happens to open a project in
the current directory), we can be more explicit and open the chosen project
or workspace file. This has the nice benefit of explicitly opening the
project that users have specified in their config. This means that this
command will now work properly if the user is trying to work with a project
that lives in a nested subdirectory (like is the case with React Native
projects)