### PR TITLE
Add .gitignore file with doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
I did this so that people can use git submodules to manage their Vim
plugins without having the Vim generated documentation tags be
identified as a change.