### PR TITLE
Set scheme auto-detection to disfavor example and demo schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ let g:xcode_project_file = 'path/to/project.xcodeproj'
 let g:xcode_default_scheme = 'MyScheme'
 ```
 
+If setting a scheme for each project doesn't work for you,
+you can set an ignore pattern to filter out schemes you don't
+want to be selected by default.
+```
+let g:xcode_scheme_ignore_pattern = "/Demo|Example/d"
+```
+
 You can also specify a custom default simulator to use:
 
 ```

--- a/bin/list_schemes.sh
+++ b/bin/list_schemes.sh
@@ -5,4 +5,5 @@ set -o pipefail
 xcrun xcodebuild -list "$@" 2>/dev/null \
   | awk '/Schemes:/,0' \
   | tail -n +2 \
+  | sed -E '/demo|Demo|Example|example/d' \
   | sed -e "s/^[[:space:]]*//"

--- a/bin/list_schemes.sh
+++ b/bin/list_schemes.sh
@@ -2,17 +2,29 @@
 
 set -o pipefail
 
-ignore_pattern="$1"
+while getopts "t:i:" opt; do
+    case $opt in
+        t) target="$OPTARG";;
+        i) ignore_pattern="$OPTARG";;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 1
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument" >&2
+            exit 1
+            ;;
+    esac
+done
 
-if [[ "$ignore_pattern" == "-workspace" ]]; then
+schemes="$(
     xcrun xcodebuild -list 2>/dev/null \
-      | awk '/Schemes:/,0' \
-      | tail -n +2 \
-      | sed -e "s/^[[:space:]]*//"
-else
-    xcrun xcodebuild -list 2>/dev/null \
-      | awk '/Schemes:/,0' \
-      | tail -n +2 \
-      | sed -E "$ignore_pattern" \
-      | sed -e "s/^[[:space:]]*//"
+    | awk '/Schemes:/,0' \
+    | tail -n +2 \
+    | sed -e "s/^[[:space:]]*//"
+)"
+
+if [[ $ignore_pattern ]]; then
+    sed -E "$ignore_pattern"
 fi
+

--- a/bin/list_schemes.sh
+++ b/bin/list_schemes.sh
@@ -3,30 +3,30 @@
 set -o pipefail
 
 while getopts "t:i:" opt; do
-    case $opt in
-        t) target="$OPTARG";;
-        i) ignore_pattern="$OPTARG";;
-        \?)
-            echo "Invalid option: -$OPTARG" >&2
-            exit 1
-            ;;
-        :)
-            echo "Option -$OPTARG requires an argument" >&2
-            exit 1
-            ;;
-    esac
+  case $opt in
+    t) target="$OPTARG";;
+    i) ignore_pattern="$OPTARG";;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument" >&2
+      exit 1
+      ;;
+  esac
 done
 
 schemes="$(
-    xcrun xcodebuild -list 2>/dev/null \
-    | awk '/Schemes:/,0' \
-    | tail -n +2 \
-    | sed -e "s/^[[:space:]]*//"
+  xcrun xcodebuild -list 2>/dev/null \
+  | awk '/Schemes:/,0' \
+  | tail -n +2 \
+  | sed -e "s/^[[:space:]]*//"
 )"
 
 if [[ $ignore_pattern ]]; then
-    echo "$schemes" | sed -E "$ignore_pattern"
+  echo "$schemes" | sed -E "$ignore_pattern"
 else
-    echo "$schemes"
+  echo "$schemes"
 fi
 

--- a/bin/list_schemes.sh
+++ b/bin/list_schemes.sh
@@ -27,9 +27,9 @@ schemes="$(
   | sed -e "s/^[[:space:]]*//"
 )"
 
-if [[ $ignore_pattern ]]; then
-  echo "$schemes" | sed -E "$ignore_pattern"
-else
+if [ -z "$ignore_pattern" ]; then
   echo "$schemes"
+else
+  echo "$schemes" | sed -E "$ignore_pattern"
 fi
 

--- a/bin/list_schemes.sh
+++ b/bin/list_schemes.sh
@@ -4,7 +4,7 @@ set -o pipefail
 
 while getopts "t:i:" opt; do
   case $opt in
-    t) target="$OPTARG";;
+    t) flag_and_target="$OPTARG";;
     i) ignore_pattern="$OPTARG";;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -17,8 +17,11 @@ while getopts "t:i:" opt; do
   esac
 done
 
+flag="$(echo "$flag_and_target" | cut -d ' ' -f1)"
+target="$(echo "$flag_and_target" | cut -d ' ' -f2)"
+
 schemes="$(
-  xcrun xcodebuild -list 2>/dev/null \
+  xcrun xcodebuild -list "$flag" "$target" 2>/dev/null \
   | awk '/Schemes:/,0' \
   | tail -n +2 \
   | sed -e "s/^[[:space:]]*//"

--- a/bin/list_schemes.sh
+++ b/bin/list_schemes.sh
@@ -4,7 +4,7 @@ set -o pipefail
 
 ignore_pattern="$1"
 
-if [[ -z "$ignore_pattern" ]]; then
+if [[ "$ignore_pattern" == "-workspace" ]]; then
     xcrun xcodebuild -list 2>/dev/null \
       | awk '/Schemes:/,0' \
       | tail -n +2 \

--- a/bin/list_schemes.sh
+++ b/bin/list_schemes.sh
@@ -25,6 +25,8 @@ schemes="$(
 )"
 
 if [[ $ignore_pattern ]]; then
-    sed -E "$ignore_pattern"
+    echo "$schemes" | sed -E "$ignore_pattern"
+else
+    echo "$schemes"
 fi
 

--- a/bin/list_schemes.sh
+++ b/bin/list_schemes.sh
@@ -2,8 +2,17 @@
 
 set -o pipefail
 
-xcrun xcodebuild -list "$@" 2>/dev/null \
-  | awk '/Schemes:/,0' \
-  | tail -n +2 \
-  | sed -E '/demo|Demo|Example|example/d' \
-  | sed -e "s/^[[:space:]]*//"
+ignore_pattern="$1"
+
+if [[ -z "$ignore_pattern" ]]; then
+    xcrun xcodebuild -list 2>/dev/null \
+      | awk '/Schemes:/,0' \
+      | tail -n +2 \
+      | sed -e "s/^[[:space:]]*//"
+else
+    xcrun xcodebuild -list 2>/dev/null \
+      | awk '/Schemes:/,0' \
+      | tail -n +2 \
+      | sed -E "$ignore_pattern" \
+      | sed -e "s/^[[:space:]]*//"
+fi

--- a/bin/list_schemes.sh
+++ b/bin/list_schemes.sh
@@ -2,9 +2,10 @@
 
 set -o pipefail
 
-while getopts "t:i:" opt; do
+while getopts "f:t:i:" opt; do
   case $opt in
-    t) flag_and_target="$OPTARG";;
+    f) flag="$OPTARG";;
+    t) target="$OPTARG";;
     i) ignore_pattern="$OPTARG";;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -16,9 +17,6 @@ while getopts "t:i:" opt; do
       ;;
   esac
 done
-
-flag="$(echo "$flag_and_target" | cut -d ' ' -f1)"
-target="$(echo "$flag_and_target" | cut -d ' ' -f2)"
 
 schemes="$(
   xcrun xcodebuild -list "$flag" "$target" 2>/dev/null \

--- a/bin/list_schemes.sh
+++ b/bin/list_schemes.sh
@@ -4,7 +4,7 @@ set -o pipefail
 
 while getopts "f:t:i:" opt; do
   case $opt in
-    f) flag="$OPTARG";;
+    f) target_type_flag="$OPTARG";;
     t) target="$OPTARG";;
     i) ignore_pattern="$OPTARG";;
     \?)
@@ -19,7 +19,7 @@ while getopts "f:t:i:" opt; do
 done
 
 schemes="$(
-  xcrun xcodebuild -list "$flag" "$target" 2>/dev/null \
+  xcrun xcodebuild -list "$target_type_flag" "$target" 2>/dev/null \
   | awk '/Schemes:/,0' \
   | tail -n +2 \
   | sed -e "s/^[[:space:]]*//"
@@ -30,4 +30,3 @@ if [ -z "$ignore_pattern" ]; then
 else
   echo "$schemes" | sed -E "$ignore_pattern"
 fi
-

--- a/doc/xcode.txt
+++ b/doc/xcode.txt
@@ -26,7 +26,8 @@ CONTENTS                                                        *xcode-Contents*
         3.4 .............................. |xcode_workspace_file|
         3.5 .............................. |xcode_project_file|
         3.6 .............................. |xcode_default_scheme|
-        3.7 .............................. |xcode_default_simulator|
+        3.7 .............................. |xcode_scheme_ignore_pattern|
+        3.8 .............................. |xcode_default_simulator|
 
 ==============================================================================
 ABOUT (1)                                                          *xcode-About*
@@ -286,8 +287,22 @@ If not set, `xcode.vim` will default to the first scheme listed as a result of
 `xcodebuild -list`
 
 ------------------------------------------------------------------------------
+                                                       *xcode_scheme_ignore_pattern*
+3.7 g:xcode_scheme_ignore_pattern~
+
+The optional ignore pattern when listing/building Xcode schemes.
+
+Patterns can be any entended regular expression. This setting is useful if you
+have multiple schemes in your project/workspace, and you wish to always
+ignore demo apps for example. Also, setting this scheme can help you avoid
+having to set an xcode_default_scheme for each project.
+
+If not set, `xcode.vim` will default to the first scheme listed as a result of
+`xcodebuild -list` or the scheme set as the `xcode_default_scheme`.
+
+------------------------------------------------------------------------------
                                                        *xcode_default_simulator*
-3.6 g:xcode_default_simulator~
+3.8 g:xcode_default_simulator~
 
 The default simulator to use for building/testing/running.
 

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -277,7 +277,7 @@ function! s:get_available_schemes()
     let scheme_command .= ' ' . '-i' . s:cli_args(g:xcode_scheme_ignore_pattern)
   endif
 
-  let scheme_command .= ' ' . '-t' . s:build_target()
+  let scheme_command .= ' ' . '-t' . ' ' . shellescape(s:build_target())
   let s:available_schemes = systemlist(scheme_command)
 endfunction
 

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -274,7 +274,7 @@ endfunction
 function! s:get_available_schemes()
   let scheme_command = 'source ' . s:bin_script('list_schemes.sh')
   if exists('g:xcode_scheme_ignore_pattern')
-     let scheme_command .= ' ' . '-i' . s:cli_args(g:xcode_scheme_ignore_pattern)
+    let scheme_command .= ' ' . '-i' . s:cli_args(g:xcode_scheme_ignore_pattern)
   endif
 
   let scheme_command .= ' ' . '-t' . s:build_target()

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -197,10 +197,22 @@ function! s:build_target_with_scheme()
 endfunction
 
 function! s:build_target()
+  return s:build_target_flag() . ' ' . s:build_target_argument()
+endfunction
+
+function! s:build_target_flag()
   if s:workspace_exists()
-    return '-workspace' . s:cli_args(s:workspace_file())
+    return '-workspace'
   else
-    return '-project' . s:cli_args(s:project_file())
+    return '-project'
+  endif
+endfunction
+
+function! s:build_target_argument()
+  if s:workspace_exists()
+    return s:cli_args(s:workspace_file())
+  else
+    return s:cli_args(s:project_file())
   endif
 endfunction
 
@@ -272,12 +284,21 @@ function! s:schemes()
 endfunction
 
 function! s:get_available_schemes()
-  let scheme_command = 'source ' . s:bin_script('list_schemes.sh')
+  let scheme_command = 'source '
+                    \ . s:bin_script('list_schemes.sh')
+                    \ . ' '
+                    \ . '-f'
+                    \ . ' '
+                    \ . s:build_target_flag()
+                    \ . ' '
+                    \ . '-t'
+                    \ . ' '
+                    \ . s:build_target_argument()
+
   if exists('g:xcode_scheme_ignore_pattern')
     let scheme_command .= ' ' . '-i' . s:cli_args(g:xcode_scheme_ignore_pattern)
   endif
 
-  let scheme_command .= ' ' . '-t' . ' ' . shellescape(s:build_target())
   let s:available_schemes = systemlist(scheme_command)
 endfunction
 

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -266,14 +266,19 @@ endfunction
 
 function! s:schemes()
   if !exists('s:available_schemes')
-    if exists('g:xcode_scheme_ignore_pattern')
-      let s:available_schemes = systemlist('source ' . s:bin_script('list_schemes.sh') . s:cli_args(g:xcode_scheme_ignore_pattern) . ' ' . s:build_target())
-    else
-      let s:available_schemes = systemlist('source ' . s:bin_script('list_schemes.sh') . ' ' . s:build_target())
-    endif
+      call s:get_available_schemes()
   endif
-
   return s:available_schemes
+endfunction
+
+function! s:get_available_schemes()
+    let scheme_command = 'source ' . s:bin_script('list_schemes.sh')
+    if exists('g:xcode_scheme_ignore_pattern')
+       let scheme_command .= ' ' . '-i' . s:cli_args(g:xcode_scheme_ignore_pattern)
+    endif
+
+    let scheme_command .= ' ' . '-t' . s:build_target()
+    let s:available_schemes = systemlist(scheme_command)
 endfunction
 
 function! s:simulator()

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -37,6 +37,8 @@ let s:default_simulator = 'iPhone 6s'
 
 let s:plugin_path = expand('<sfile>:p:h:h')
 
+let s:xcode_scheme_ignore_pattern = ''
+
 function! s:bin_script(name)
   return s:plugin_path . '/bin/' . a:name
 endfunction
@@ -266,7 +268,14 @@ endfunction
 
 function! s:schemes()
   if !exists('s:available_schemes')
-    let s:available_schemes = systemlist('source ' . s:bin_script('list_schemes.sh') . ' ' . s:build_target())
+    if exists('g:xcode_scheme_ignore_pattern')
+      " Do I need an s: style local var here?
+      let s:xcode_scheme_ignore_pattern = g:xcode_scheme_ignore_pattern
+      echo "Ignore pattern: " . s:xcode_scheme_ignore_pattern
+      let s:available_schemes = systemlist('source ' . s:bin_script('list_schemes.sh' . ' ' . s:xcode_scheme_ignore_pattern) . ' ' . s:build_target())
+    else
+      let s:available_schemes = systemlist('source ' . s:bin_script('list_schemes.sh') . ' ' . s:build_target())
+    endif
   endif
 
   return s:available_schemes

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -37,8 +37,6 @@ let s:default_simulator = 'iPhone 6s'
 
 let s:plugin_path = expand('<sfile>:p:h:h')
 
-let s:xcode_scheme_ignore_pattern = ''
-
 function! s:bin_script(name)
   return s:plugin_path . '/bin/' . a:name
 endfunction
@@ -269,10 +267,7 @@ endfunction
 function! s:schemes()
   if !exists('s:available_schemes')
     if exists('g:xcode_scheme_ignore_pattern')
-      " Do I need an s: style local var here?
-      let s:xcode_scheme_ignore_pattern = g:xcode_scheme_ignore_pattern
-      echo "Ignore pattern: " . s:xcode_scheme_ignore_pattern
-      let s:available_schemes = systemlist('source ' . s:bin_script('list_schemes.sh' . ' ' . s:xcode_scheme_ignore_pattern) . ' ' . s:build_target())
+      let s:available_schemes = systemlist('source ' . s:bin_script('list_schemes.sh') . s:cli_args(g:xcode_scheme_ignore_pattern) . ' ' . s:build_target())
     else
       let s:available_schemes = systemlist('source ' . s:bin_script('list_schemes.sh') . ' ' . s:build_target())
     endif

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -202,9 +202,9 @@ endfunction
 
 function! s:build_target_flag()
   if s:workspace_exists()
-    return '-workspace'
+    return s:cli_args('-workspace')
   else
-    return '-project'
+    return s:cli_args('-project')
   endif
 endfunction
 
@@ -288,11 +288,9 @@ function! s:get_available_schemes()
                     \ . s:bin_script('list_schemes.sh')
                     \ . ' '
                     \ . '-f'
-                    \ . ' '
                     \ . s:build_target_flag()
                     \ . ' '
                     \ . '-t'
-                    \ . ' '
                     \ . s:build_target_argument()
 
   if exists('g:xcode_scheme_ignore_pattern')

--- a/plugin/xcode.vim
+++ b/plugin/xcode.vim
@@ -266,19 +266,19 @@ endfunction
 
 function! s:schemes()
   if !exists('s:available_schemes')
-      call s:get_available_schemes()
+    call s:get_available_schemes()
   endif
   return s:available_schemes
 endfunction
 
 function! s:get_available_schemes()
-    let scheme_command = 'source ' . s:bin_script('list_schemes.sh')
-    if exists('g:xcode_scheme_ignore_pattern')
-       let scheme_command .= ' ' . '-i' . s:cli_args(g:xcode_scheme_ignore_pattern)
-    endif
+  let scheme_command = 'source ' . s:bin_script('list_schemes.sh')
+  if exists('g:xcode_scheme_ignore_pattern')
+     let scheme_command .= ' ' . '-i' . s:cli_args(g:xcode_scheme_ignore_pattern)
+  endif
 
-    let scheme_command .= ' ' . '-t' . s:build_target()
-    let s:available_schemes = systemlist(scheme_command)
+  let scheme_command .= ' ' . '-t' . s:build_target()
+  let s:available_schemes = systemlist(scheme_command)
 endfunction
 
 function! s:simulator()


### PR DESCRIPTION
## What
I made the scheme auto-detection avoid setting the scheme to names with "E/example" or "D/demo" in their name.

## Why
I found it a little tedious to set a custom vimrc for every project.

## How
I added a line to `list_schemes.sh` to exclude the scheme names above.

## Questions/Concerns
Any other scheme names I should disfavor?